### PR TITLE
Trace-centric meters

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+scripts/* linguist-documentation

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/
 .*
 !.travis.yml
 !.coveragerc
+!.gitattributes

--- a/eemeter/ee/aggregate.py
+++ b/eemeter/ee/aggregate.py
@@ -99,10 +99,14 @@ class Aggregator(object):
                     (reporting_status in ["ACCEPTED", "DEFAULT"])):
                 baseline_derivatives.append(baseline_derivative)
                 reporting_derivatives.append(reporting_derivative)
+                pair_status = "ACCEPTED"
+            else:
+                pair_status = "REJECTED"
 
             statuses[pair.label] = OrderedDict([
                 ("baseline_status", baseline_status),
                 ("reporting_status", reporting_status),
+                ("status", pair_status),
             ])
 
         return baseline_derivatives, reporting_derivatives, statuses

--- a/eemeter/ee/aggregate.py
+++ b/eemeter/ee/aggregate.py
@@ -16,10 +16,10 @@ class Aggregator(object):
     Enforces trace interpretation uniformity, aggregates according to the
     aggregation rules supplied.
     """
+
     aggregation_functions = {
         "SUM": sum_func,
     }
-
 
     def __init__(self, aggregation_function="SUM",
                  baseline_default_value=None,

--- a/eemeter/ee/aggregate.py
+++ b/eemeter/ee/aggregate.py
@@ -125,12 +125,7 @@ class Aggregator(object):
 
         Parameters
         ----------
-        derivative_pairs : list of eemeter.ee.meter.Derivative
-            Derivative pairs to be aggregated; should be at least one.
-        target_interpretation : str, default None
-            Interpretation of derivatives; if None, will use interpretation of
-            first.
-        target_unit : str, default None
+        aggregation_input : str, default None
             Unit of derivatives; if None, will use unit of first.
         '''
         deserialized = deserialize_aggregation_input(aggregation_input)
@@ -188,5 +183,9 @@ class Aggregator(object):
 
         return OrderedDict([
             ("aggregated", aggregated),
+            ("aggregation_interpretation", aggregation_interpretation),
+            ("derivative_interpretation", target_derivative_interpretation),
+            ("trace_interpretation", target_trace_interpretation),
+            ("unit", target_unit),
             ("status", status),
         ])

--- a/eemeter/ee/aggregate.py
+++ b/eemeter/ee/aggregate.py
@@ -50,24 +50,36 @@ class Aggregator(object):
                 )
                 raise ValueError(message)
 
+    def _derivative_is_valid(self, derivative):
+        return not (
+            derivative.value is None or
+            derivative.lower is None or
+            derivative.upper is None or
+            derivative.n is None
+        )
+
     def _get_valid_derivatives(self, derivative_pairs):
         baseline_derivatives, reporting_derivatives = [], []
         n_valid = 0
         n_invalid = 0
 
         for pair in derivative_pairs:
+
             baseline_derivative = pair.baseline
-            if baseline_derivative is None:
+            baseline_valid = self._derivative_is_valid(baseline_derivative)
+            if not baseline_valid:
                 if self.baseline_default_value is not None:
                     baseline_derivative = self.baseline_default_value
+                    baseline_valid = True
 
             reporting_derivative = pair.reporting
-            if reporting_derivative is None:
+            reporting_valid = self._derivative_is_valid(reporting_derivative)
+            if not reporting_valid:
                 if self.reporting_default_value is not None:
                     reporting_derivative = self.reporting_default_value
+                    reporting_valid = True
 
-            if baseline_derivative is not None and \
-                    reporting_derivative is not None:
+            if baseline_valid and reporting_valid:
                 baseline_derivatives.append(baseline_derivative)
                 reporting_derivatives.append(reporting_derivative)
                 n_valid += 1

--- a/eemeter/ee/aggregate.py
+++ b/eemeter/ee/aggregate.py
@@ -1,0 +1,85 @@
+from eemeter.ee.derivatives import DerivativePair
+
+
+class Aggregator(object):
+    """
+    Enforces trace interpretation uniformity, aggregates according to the
+    aggregation rules supplied.
+    """
+
+    def __init__(self, func,
+                 baseline_default_value=None,
+                 reporting_default_value=None):
+        self.func = func
+        self.baseline_default_value = baseline_default_value
+        self.reporting_default_value = reporting_default_value
+
+    def _validate_interpretation(self, derivative_pairs,
+                                 target_interpretation):
+        for d in derivative_pairs:
+            if d.interpretation != target_interpretation:
+                message = (
+                    "DerivativePair interpretation ({}) does not match"
+                    " target_interpretation ({})."
+                    .format(d.interpretation, target_interpretation)
+                )
+                raise ValueError(message)
+
+    def _get_valid_derivatives(self, derivative_pairs):
+        baseline_derivatives, reporting_derivatives = [], []
+        n_valid = 0
+        n_invalid = 0
+
+        for pair in derivative_pairs:
+            baseline_derivative = pair.baseline
+            if baseline_derivative is None:
+                if self.baseline_default_value is not None:
+                    baseline_derivative = self.baseline_default_value
+
+            reporting_derivative = pair.reporting
+            if reporting_derivative is None:
+                if self.reporting_default_value is not None:
+                    reporting_derivative = self.reporting_default_value
+
+            if baseline_derivative is not None and \
+                    reporting_derivative is not None:
+                baseline_derivatives.append(baseline_derivative)
+                reporting_derivatives.append(reporting_derivative)
+                n_valid += 1
+            else:
+                n_invalid += 1
+
+        return baseline_derivatives, reporting_derivatives, n_valid, n_invalid
+
+    def _aggregate(self, derivatives):
+        if len(derivatives) == 0:
+            return None
+
+        aggregated = derivatives[0]
+        for d in derivatives[1:]:
+            aggregated = self.func(aggregated, d)
+        return aggregated
+
+    def aggregate(self, derivative_pairs, target_interpretation):
+        ''' Aggregates derivative pairs
+
+        Parameters
+        ----------
+        derivative_pairs : list of eemeter.ee.meter.Derivative
+            Derivative pairs to be aggregated.
+        target_interpretation : str
+            Interpretation of derivatives.
+        '''
+        self._validate_interpretation(derivative_pairs, target_interpretation)
+
+        baseline_derivatives, reporting_derivatives, n_valid, n_invalid = \
+            self._get_valid_derivatives(derivative_pairs)
+
+        baseline_aggregation = self._aggregate(baseline_derivatives)
+        reporting_aggregation = self._aggregate(reporting_derivatives)
+
+        aggregated = DerivativePair(
+            target_interpretation, baseline_aggregation, reporting_aggregation
+        )
+
+        return aggregated, n_valid, n_invalid

--- a/eemeter/ee/aggregate.py
+++ b/eemeter/ee/aggregate.py
@@ -133,7 +133,6 @@ class Aggregator(object):
         target_unit : str, default None
             Unit of derivatives; if None, will use unit of first.
         '''
-
         deserialized = deserialize_aggregation_input(aggregation_input)
 
         aggregation_interpretation = deserialized["aggregation_interpretation"]
@@ -177,13 +176,17 @@ class Aggregator(object):
         baseline_aggregation = self._aggregate(baseline_derivatives, func)
         reporting_aggregation = self._aggregate(reporting_derivatives, func)
 
-        aggregated = DerivativePair(
-            None, target_derivative_interpretation,
-            target_trace_interpretation, target_unit,
-            baseline_aggregation, reporting_aggregation
-        )
+        if baseline_aggregation is None or reporting_aggregation is None:
+            aggregated = None
+        else:
+            aggregated = DerivativePair(
+                None, target_derivative_interpretation,
+                target_trace_interpretation, target_unit,
+                baseline_aggregation, reporting_aggregation
+            )
+            aggregated = serialize_derivative_pair(aggregated)
 
         return OrderedDict([
-            ("aggregated", serialize_derivative_pair(aggregated)),
+            ("aggregated", aggregated),
             ("status", status),
         ])

--- a/eemeter/ee/aggregate.py
+++ b/eemeter/ee/aggregate.py
@@ -8,6 +8,7 @@ def sum_func(d1, d2):
         (d1.lower**2 + d2.lower**2)**0.5,
         (d1.upper**2 + d2.upper**2)**0.5,
         d1.n + d2.n,
+        None,
     )
 
 

--- a/eemeter/ee/aggregate.py
+++ b/eemeter/ee/aggregate.py
@@ -1,4 +1,14 @@
-from eemeter.ee.derivatives import DerivativePair
+from eemeter.ee.derivatives import DerivativePair, Derivative
+
+
+def sum_func(d1, d2):
+    return Derivative(
+        None,
+        d1.value + d2.value,
+        (d1.lower**2 + d2.lower**2)**0.5,
+        (d1.upper**2 + d2.upper**2)**0.5,
+        d1.n + d2.n,
+    )
 
 
 class Aggregator(object):
@@ -6,11 +16,15 @@ class Aggregator(object):
     Enforces trace interpretation uniformity, aggregates according to the
     aggregation rules supplied.
     """
+    aggregation_functions = {
+        "SUM": sum_func,
+    }
 
-    def __init__(self, func,
+
+    def __init__(self, aggregation_function="SUM",
                  baseline_default_value=None,
                  reporting_default_value=None):
-        self.func = func
+        self.func = self.aggregation_functions[aggregation_function]
         self.baseline_default_value = baseline_default_value
         self.reporting_default_value = reporting_default_value
 

--- a/eemeter/ee/derivatives.py
+++ b/eemeter/ee/derivatives.py
@@ -6,7 +6,7 @@ import pytz
 
 
 DerivativePair = namedtuple('DerivativePair', [
-    'interpretation', 'unit', 'baseline', 'reporting'
+    'derivative_interpretation', 'trace_interpretation', 'unit', 'baseline', 'reporting'
 ])
 
 

--- a/eemeter/ee/derivatives.py
+++ b/eemeter/ee/derivatives.py
@@ -11,7 +11,7 @@ DerivativePair = namedtuple('DerivativePair', [
 
 
 Derivative = namedtuple('Derivative', [
-    'label', 'value', 'lower', 'upper', 'n'
+    'label', 'value', 'lower', 'upper', 'n', 'serialized_demand_fixture'
 ])
 
 
@@ -54,6 +54,9 @@ def annualized_weather_normal(formatter, model, weather_normal_source):
     demand_fixture_data = formatter.create_demand_fixture(
             normal_index, weather_normal_source)
 
+    serialized_demand_fixture = \
+        formatter.serialize_demand_fixture(demand_fixture_data)
+
     normals = model.predict(demand_fixture_data)
     annualized = normals.sum()
     n = normal_index.shape[0]
@@ -61,7 +64,7 @@ def annualized_weather_normal(formatter, model, weather_normal_source):
     lower = (model.lower**2 * n)**0.5
 
     return {
-        "annualized_weather_normal": (annualized, lower, upper, n),
+        "annualized_weather_normal": (annualized, lower, upper, n, serialized_demand_fixture),
     }
 
 
@@ -113,6 +116,9 @@ def gross_predicted(formatter, model, weather_source, reporting_period):
     demand_fixture_data = formatter.create_demand_fixture(
         index, weather_source)
 
+    serialized_demand_fixture = \
+        formatter.serialize_demand_fixture(demand_fixture_data)
+
     values = model.predict(demand_fixture_data)
     gross_predicted = values.sum()
     n = index.shape[0]
@@ -120,5 +126,5 @@ def gross_predicted(formatter, model, weather_source, reporting_period):
     lower = (model.lower**2 * n)**0.5
 
     return {
-        "gross_predicted": (gross_predicted, lower, upper, n),
+        "gross_predicted": (gross_predicted, lower, upper, n, serialized_demand_fixture),
     }

--- a/eemeter/ee/derivatives.py
+++ b/eemeter/ee/derivatives.py
@@ -6,7 +6,8 @@ import pytz
 
 
 DerivativePair = namedtuple('DerivativePair', [
-    'derivative_interpretation', 'trace_interpretation', 'unit', 'baseline', 'reporting'
+    'label', 'derivative_interpretation', 'trace_interpretation', 'unit',
+    'baseline', 'reporting'
 ])
 
 

--- a/eemeter/ee/derivatives.py
+++ b/eemeter/ee/derivatives.py
@@ -1,7 +1,18 @@
 from datetime import datetime
+from collections import namedtuple
 
 import pandas as pd
 import pytz
+
+
+DerivativePair = namedtuple('DerivativePair', [
+    'interpretation', 'baseline', 'reporting'
+])
+
+
+Derivative = namedtuple('Derivative', [
+    'label', 'value', 'lower', 'upper', 'n'
+])
 
 
 def annualized_weather_normal(formatter, model, weather_normal_source):

--- a/eemeter/ee/derivatives.py
+++ b/eemeter/ee/derivatives.py
@@ -64,7 +64,8 @@ def annualized_weather_normal(formatter, model, weather_normal_source):
     lower = (model.lower**2 * n)**0.5
 
     return {
-        "annualized_weather_normal": (annualized, lower, upper, n, serialized_demand_fixture),
+        "annualized_weather_normal": (annualized, lower, upper, n,
+                                      serialized_demand_fixture),
     }
 
 
@@ -126,5 +127,6 @@ def gross_predicted(formatter, model, weather_source, reporting_period):
     lower = (model.lower**2 * n)**0.5
 
     return {
-        "gross_predicted": (gross_predicted, lower, upper, n, serialized_demand_fixture),
+        "gross_predicted": (gross_predicted, lower, upper, n,
+                            serialized_demand_fixture),
     }

--- a/eemeter/ee/derivatives.py
+++ b/eemeter/ee/derivatives.py
@@ -6,7 +6,7 @@ import pytz
 
 
 DerivativePair = namedtuple('DerivativePair', [
-    'interpretation', 'baseline', 'reporting'
+    'interpretation', 'unit', 'baseline', 'reporting'
 ])
 
 

--- a/eemeter/ee/meter.py
+++ b/eemeter/ee/meter.py
@@ -22,6 +22,7 @@ from eemeter.modeling.split import (
 from eemeter.io.serializers import (
     deserialize_meter_input,
     serialize_derivative_pairs,
+    serialize_split_modeled_energy_trace,
 )
 from eemeter.processors.dispatchers import (
     get_approximate_frequency,
@@ -662,7 +663,8 @@ class EnergyEfficiencyMeterTraceCentric(object):
             trace, formatter_instance, model_mapping, modeling_period_set)
 
         modeled_energy_trace.fit(weather_source)
-        # output["modeled_energy_trace"] = modeled_energy_trace
+        output["modeled_energy_trace"] = \
+            serialize_split_modeled_energy_trace(modeled_energy_trace)
 
         # Step 9: for each modeling period group, create derivatives
         derivative_pairs = []

--- a/eemeter/ee/meter.py
+++ b/eemeter/ee/meter.py
@@ -717,7 +717,7 @@ class EnergyEfficiencyMeterTraceCentric(object):
                         )
 
                 derivative_pair = DerivativePair(
-                    interpretation, trace.unit,
+                    interpretation, trace.interpretation, trace.unit,
                     baseline_derivative, reporting_derivative
                 )
                 return derivative_pair

--- a/eemeter/ee/meter.py
+++ b/eemeter/ee/meter.py
@@ -717,7 +717,8 @@ class EnergyEfficiencyMeterTraceCentric(object):
                         )
 
                 derivative_pair = DerivativePair(
-                    interpretation, baseline_derivative, reporting_derivative
+                    interpretation, trace.unit,
+                    baseline_derivative, reporting_derivative
                 )
                 return derivative_pair
 

--- a/eemeter/ee/meter.py
+++ b/eemeter/ee/meter.py
@@ -688,7 +688,8 @@ class EnergyEfficiencyMeterTraceCentric(object):
             def _compute_derivative(baseline_label, reporting_label,
                                     interpretation, derivative_func, kwargs):
 
-                baseline_derivative = None
+                baseline_derivative = \
+                    Derivative(baseline_label, None, None, None, None, None)
                 if baseline_model_success:
                     baseline_derivative = modeled_energy_trace \
                         .compute_derivative(
@@ -701,7 +702,8 @@ class EnergyEfficiencyMeterTraceCentric(object):
                             serialized_demand_fixture
                         )
 
-                reporting_derivative = None
+                reporting_derivative = \
+                    Derivative(reporting_label, None, None, None, None, None)
                 if reporting_model_success:
                     reporting_derivative = modeled_energy_trace \
                         .compute_derivative(

--- a/eemeter/ee/meter.py
+++ b/eemeter/ee/meter.py
@@ -717,7 +717,7 @@ class EnergyEfficiencyMeterTraceCentric(object):
                         )
 
                 derivative_pair = DerivativePair(
-                    interpretation, trace.interpretation, trace.unit,
+                    None, interpretation, trace.interpretation, trace.unit,
                     baseline_derivative, reporting_derivative
                 )
                 return derivative_pair

--- a/eemeter/ee/meter.py
+++ b/eemeter/ee/meter.py
@@ -599,7 +599,7 @@ class EnergyEfficiencyMeterTraceCentric(object):
                     "Default formatter mapping did not find a match for"
                     " the selector {}".format(selector)
                 )
-                output['status'] == FAILURE
+                output['status'] = FAILURE
                 output['failure_message'] = message
                 return output
         else:

--- a/eemeter/ee/meter.py
+++ b/eemeter/ee/meter.py
@@ -373,9 +373,7 @@ class EnergyEfficiencyMeterTraceCentric(object):
     def __init__(self, default_model_mapping=None, default_formatter_mapping=None):
 
         if default_formatter_mapping is None:
-            daily_formatter = (ModelDataFormatter, {
-                'freq_str': 'D'
-            })
+            daily_formatter = (ModelDataFormatter, {'freq_str': 'D'})
             billing_formatter = (ModelDataBillingFormatter, {})
             default_formatter_mapping = {
                 ('NATURAL_GAS_CONSUMPTION_SUPPLIED', '15T'): daily_formatter,
@@ -555,7 +553,7 @@ class EnergyEfficiencyMeterTraceCentric(object):
                 return output
         else:
             FormatterClass, formatter_kwargs = formatter
-        formatter_instance = FormatterClass(formatter_kwargs)
+        formatter_instance = FormatterClass(**formatter_kwargs)
         output["formatter_class"] = FormatterClass.__name__
         output["formatter_kwargs"] = formatter_kwargs
 
@@ -593,7 +591,7 @@ class EnergyEfficiencyMeterTraceCentric(object):
         }
 
         modeled_energy_trace = SplitModeledEnergyTrace(
-            trace, formatter, model_mapping, modeling_period_set)
+            trace, formatter_instance, model_mapping, modeling_period_set)
 
         modeled_energy_trace.fit(weather_source)
         output["modeled_energy_trace"] = modeled_energy_trace
@@ -622,7 +620,8 @@ class EnergyEfficiencyMeterTraceCentric(object):
                         .compute_derivative(
                             baseline_label, derivative_func, **kwargs)
                     if baseline_derivative is not None:
-                        value, lower, upper, n = derivative[interpretation]
+                        value, lower, upper, n = \
+                            baseline_derivative[interpretation]
                         baseline_derivative = Derivative(
                             baseline_label, value, lower, upper, n
                         )
@@ -633,7 +632,8 @@ class EnergyEfficiencyMeterTraceCentric(object):
                         .compute_derivative(
                             reporting_label, derivative_func, **kwargs)
                     if reporting_derivative is not None:
-                        value, lower, upper, n = derivative[interpretation]
+                        value, lower, upper, n = \
+                            reporting_derivative[interpretation]
                         reporting_derivative = Derivative(
                             reporting_label, value, lower, upper, n
                         )

--- a/eemeter/ee/meter.py
+++ b/eemeter/ee/meter.py
@@ -533,39 +533,19 @@ class EnergyEfficiencyMeterTraceCentric(object):
                 "Meter input could not be deserialized:\n{}"
                 .format(deserialized_input)
             )
-            output['status'] == FAILURE
+            output['status'] = FAILURE
             output['failure_message'] = message
             return output
 
-        trace = deserialized_input.get("trace", None)
-        if trace is None:
-            message = (
-                "Trace data not found in meter input."
-            )
-            output['status'] == FAILURE
-            output['failure_message'] = message
-            return output
-
-        project = deserialized_input.get("project", None)
-        if trace is None:
-            message = (
-                "Project data not found in meter input."
-            )
-            output['status'] == FAILURE
-            output['failure_message'] = message
-            return output
-
-        zipcode = project.get("zipcode", None)
-        if zipcode is None:
-            message = (
-                "ZIP code project data not found in meter input."
-            )
-            output['status'] == FAILURE
-            output['failure_message'] = message
-            return output
+        # Assume that deserialized input fails without these keys, so don't
+        # bother error checking
+        trace = deserialized_input["trace"]
+        project = deserialized_input["project"]
+        zipcode = project["zipcode"]
         site = ZIPCodeSite(zipcode)
 
-        # can be blank for models capable of structural change analysis
+        # Can be blank for models capable of structural change analysis, so
+        # provide default
         modeling_period_set = project.get("modeling_period_set", None)
 
         # Step 2: Match weather
@@ -587,7 +567,7 @@ class EnergyEfficiencyMeterTraceCentric(object):
         output['weather_normal_source_station'] = weather_normal_source.station
         output['logs'].append(message)
 
-        # Step 3: Check to see if trace is placeholder, if so,
+        # Step 3: Check to see if trace is placeholder. If so,
         # return with SUCCESS, empty derivatives.
         if trace.placeholder:
             message = (

--- a/eemeter/ee/meter.py
+++ b/eemeter/ee/meter.py
@@ -592,6 +592,8 @@ class EnergyEfficiencyMeterTraceCentric(object):
         # Step 4: Determine trace interpretation and frequency
         if model is None or formatter is None:
             trace_interpretation = trace.interpretation
+            print(trace.data)
+            print(trace.data.index)
 
             print("Trace inferred_freq: {}".format(trace.data.index.inferred_freq))
             trace_frequency = get_approximate_frequency(trace)

--- a/eemeter/ee/meter.py
+++ b/eemeter/ee/meter.py
@@ -592,16 +592,10 @@ class EnergyEfficiencyMeterTraceCentric(object):
         # Step 4: Determine trace interpretation and frequency
         if model is None or formatter is None:
             trace_interpretation = trace.interpretation
-            print(trace.data)
-            print(trace.data.index)
-
-            print("Trace inferred_freq: {}".format(trace.data.index.inferred_freq))
             trace_frequency = get_approximate_frequency(trace)
-            print("approx freq: {}".format(trace_frequency))
 
             if trace_frequency not in ['H', 'D', '15T', '30T']:
                 trace_frequency = None
-            print("Final freq: {}".format(trace_frequency))
 
             selector = (trace_interpretation, trace_frequency)
 

--- a/eemeter/ee/meter.py
+++ b/eemeter/ee/meter.py
@@ -1,12 +1,34 @@
 import logging
+from collections import namedtuple
 
 from eemeter.processors.interventions import get_modeling_period_set
 from eemeter.processors.location import (
     get_weather_source,
     get_weather_normal_source,
 )
-from eemeter.processors.dispatchers import get_energy_modeling_dispatches
+from eemeter.processors.dispatchers import (
+    get_energy_modeling_dispatches,
+    get_approximate_frequency,
+)
 from eemeter.ee.derivatives import annualized_weather_normal, gross_predicted
+from eemeter.modeling.models.seasonal import SeasonalElasticNetCVModel
+from eemeter.modeling.formatters import (
+    ModelDataFormatter,
+    ModelDataBillingFormatter,
+)
+from eemeter.modeling.models.billing import BillingElasticNetCVModel
+from eemeter import get_version
+from eemeter.modeling.split import (
+    SplitModeledEnergyTrace
+)
+
+DerivativePair = namedtuple('DerivativePair', [
+    'interpretation', 'baseline', 'reporting'
+])
+
+Derivative = namedtuple('Derivative', [
+    'label', 'value', 'lower', 'upper', 'n'
+])
 
 logger = logging.getLogger(__name__)
 
@@ -57,17 +79,19 @@ class EnergyEfficiencyMeter(object):
             - :code:`"modeled_energy_trace_derivatives"`: derivatives for each
               modeled energy trace.
             - :code:`"project_derivatives"`: Project summaries for derivatives.
+            - :code:`"weather_source"`: Matched weather source
+            - :code:`"weather_normal_source"`: Matched weather normal source.
         '''
 
         modeling_period_set = get_modeling_period_set(project.interventions)
 
         if weather_source is None:
-            weather_source = get_weather_source(project)
+            weather_source = get_weather_source(project.site)
         else:
             logger.info("Using supplied weather_source")
 
         if weather_normal_source is None:
-            weather_normal_source = get_weather_normal_source(project)
+            weather_normal_source = get_weather_normal_source(project.site)
         else:
             logger.info("Using supplied weather_normal_source")
 
@@ -331,3 +355,334 @@ def _change_units(errors, units_from, units_to):
 
     mean, upper, lower, n = errors
     return (mean*factor, upper*factor, lower*factor, n)
+
+
+
+class EnergyEfficiencyMeterTraceCentric(object):
+    ''' Meter for determining energy efficiency derivatives for a single
+    traces.
+
+    Parameters
+    ----------
+    default_model_mapping : dict
+        mapping between (interpretation, frequency) tuples used to select
+        the default model (if none is explicitly provided in `.evaluate()`).
+
+    '''
+
+    def __init__(self, default_model_mapping=None, default_formatter_mapping=None):
+
+        if default_formatter_mapping is None:
+            daily_formatter = (ModelDataFormatter, {
+                'freq_str': 'D'
+            })
+            billing_formatter = (ModelDataBillingFormatter, {})
+            default_formatter_mapping = {
+                ('NATURAL_GAS_CONSUMPTION_SUPPLIED', '15T'): daily_formatter,
+                ('ELECTRICITY_CONSUMPTION_SUPPLIED', '15T'): daily_formatter,
+                ('ELECTRICITY_ON_SITE_GENERATION_UNCONSUMED', '15T'): daily_formatter,
+
+                ('NATURAL_GAS_CONSUMPTION_SUPPLIED', '30T'): daily_formatter,
+                ('ELECTRICITY_CONSUMPTION_SUPPLIED', '30T'): daily_formatter,
+                ('ELECTRICITY_ON_SITE_GENERATION_UNCONSUMED', '30T'): daily_formatter,
+
+                ('NATURAL_GAS_CONSUMPTION_SUPPLIED', 'H'): daily_formatter,
+                ('ELECTRICITY_CONSUMPTION_SUPPLIED', 'H'): daily_formatter,
+                ('ELECTRICITY_ON_SITE_GENERATION_UNCONSUMED', 'H'): daily_formatter,
+
+                ('NATURAL_GAS_CONSUMPTION_SUPPLIED', 'D'): daily_formatter,
+                ('ELECTRICITY_CONSUMPTION_SUPPLIED', 'D'): daily_formatter,
+                ('ELECTRICITY_ON_SITE_GENERATION_UNCONSUMED', 'D'): daily_formatter,
+
+                ('NATURAL_GAS_CONSUMPTION_SUPPLIED', None): billing_formatter,
+                ('ELECTRICITY_CONSUMPTION_SUPPLIED', None): billing_formatter,
+            }
+
+        if default_model_mapping is None:
+            seasonal_model = (SeasonalElasticNetCVModel, {
+                'cooling_base_temp': 65,
+                'heating_base_temp': 65,
+            })
+            billing_model = (BillingElasticNetCVModel, {
+                'cooling_base_temp': 65,
+                'heating_base_temp': 65,
+            })
+            default_model_mapping = {
+                ('NATURAL_GAS_CONSUMPTION_SUPPLIED', '15T'): seasonal_model,
+                ('ELECTRICITY_CONSUMPTION_SUPPLIED', '15T'): seasonal_model,
+                ('ELECTRICITY_ON_SITE_GENERATION_UNCONSUMED', '15T'): seasonal_model,
+
+                ('NATURAL_GAS_CONSUMPTION_SUPPLIED', '30T'): seasonal_model,
+                ('ELECTRICITY_CONSUMPTION_SUPPLIED', '30T'): seasonal_model,
+                ('ELECTRICITY_ON_SITE_GENERATION_UNCONSUMED', '30T'): seasonal_model,
+
+                ('NATURAL_GAS_CONSUMPTION_SUPPLIED', 'H'): seasonal_model,
+                ('ELECTRICITY_CONSUMPTION_SUPPLIED', 'H'): seasonal_model,
+                ('ELECTRICITY_ON_SITE_GENERATION_UNCONSUMED', 'H'): seasonal_model,
+
+                ('NATURAL_GAS_CONSUMPTION_SUPPLIED', 'D'): seasonal_model,
+                ('ELECTRICITY_CONSUMPTION_SUPPLIED', 'D'): seasonal_model,
+                ('ELECTRICITY_ON_SITE_GENERATION_UNCONSUMED', 'D'): seasonal_model,
+
+                ('NATURAL_GAS_CONSUMPTION_SUPPLIED', None): billing_model,
+                ('ELECTRICITY_CONSUMPTION_SUPPLIED', None): billing_model,
+            }
+
+        self.default_formatter_mapping = default_formatter_mapping
+        self.default_model_mapping = default_model_mapping
+
+    def evaluate(self, trace, site, modeling_period_set=None, formatter=None,
+                 model=None, weather_source=None, weather_normal_source=None):
+        ''' Main entry point to the meter, which models traces and calculates
+        derivatives.
+
+        Parameters
+        ----------
+        trace : eemeter.structures.EnergyTrace
+            Trace for which to evaluate meter
+        site : eemeter.structures.ZIPCodeSite
+            Contains ZIP code to match to weather stations from which to pull
+            weather data.
+        modeling_period_set : eemeter.structures.ModelPeriodSet
+            Modeling periods to use in evaluation.
+        formatter : tuple of (eemeter.modeling.Formatter class, kwargs dict), default None
+            Formatter instance for trace and weather data. Used to create input
+            for model. If None is provided, will be auto-matched to appropriate
+            default formatter.
+        model : tuple of (eemeter.modeling.Model class, kwargs dict), default None
+            Tuple of model instance to use in modeling. If None is provided,
+            will be auto-matched to appropriate default model.
+        weather_source : eemeter.weather.WeatherSource
+            Weather source to be used for this meter. Overrides weather source
+            found using :code:`project.site`. Useful for test mocking.
+        weather_normal_source : eemeter.weather.WeatherSource
+            Weather normal source to be used for this meter. Overrides weather
+            source found using :code:`project.site`. Useful for test mocking.
+
+        Returns
+        -------
+        results : dict
+            Dictionary of results with the following keys:
+
+            - :code:`"status"`: SUCCESS/FAILURE
+            - :code:`"failure_message"`: if FAILURE, message indicates reason for failure, may include traceback
+            - :code:`"logs"`: list of collected log messages
+            - :code:`"model_class"`: Name of model class
+            - :code:`"model_kwargs"`: dict of model keyword arguments (settings)
+            - :code:`"formatter_class"`: Name of formatter class
+            - :code:`"formatter_kwargs"`: dict of formatter keyword arguments (settings)
+            - :code:`"eemeter_version"`: version of the eemeter package
+            - :code:`"modeled_energy_trace"`: modeled energy trace
+            - :code:`"derivatives"`: derivatives for each interpretation
+            - :code:`"weather_source_station"`: Matched weather source station.
+            - :code:`"weather_normal_source_station"`: Matched weather normal source station.
+        '''
+
+        SUCCESS = "SUCCESS"
+        FAILURE = "FAILURE"
+
+        output = {
+            "status": None,
+            "failure_message": None,
+            "logs": [],
+
+            "eemeter_version": get_version(),
+            "model_class": None,
+            "model_kwargs": None,
+            "formatter_class": None,
+            "formatter_kwargs": None,
+
+            "modeled_energy_trace": None,
+            "derivatives": None,
+
+            "weather_source_station": None,
+            "weather_normal_source_station": None,
+        }
+
+        # Step 1: Match weather
+        if weather_source is None:
+            weather_source = get_weather_source(site)
+            message = "Using weather_source {}".format(weather_source)
+        else:
+            message = "Using supplied weather_source"
+            logger.info(message)
+        output['weather_source_station'] = weather_source.station
+        output['logs'].append(message)
+
+        if weather_normal_source is None:
+            weather_normal_source = get_weather_normal_source(site)
+            message = "Using weather_normal_source {}".format(weather_source)
+        else:
+            message = "Using supplied weather_normal_source"
+            logger.info(message)
+        output['weather_normal_source_station'] = weather_normal_source.station
+        output['logs'].append(message)
+
+        # Step 2: Check to see if trace is placeholder, if so,
+        # return with SUCCESS, empty derivatives.
+        if trace.placeholder:
+            message = (
+                'Skipping modeling for placeholder trace {}'
+                .format(trace)
+            )
+            logger.info(message)
+            output['logs'].append(message)
+            output["status"] = SUCCESS
+            output["derivatives"] = []
+            return output
+
+        # Step 3: Determine trace interpretation and frequency
+        if model is None or formatter is None:
+            trace_interpretation = trace.interpretation
+
+            trace_frequency = get_approximate_frequency(trace)
+
+            if trace_frequency not in ['H', 'D', '15T', '30T']:
+                trace_frequency = None
+
+            selector = (trace_interpretation, trace_frequency)
+
+        # Step 4: create formatter instance
+        if formatter is None:
+            FormatterClass, formatter_kwargs = self.default_formatter_mapping.get(selector, (None, None))
+            if FormatterClass is None:
+                message = (
+                    "Default formatter mapping did not find a match for"
+                    " the selector {}".format(selector)
+                )
+                output['status'] == FAILURE
+                output['failure_message'] = message
+                return output
+        else:
+            FormatterClass, formatter_kwargs = formatter
+        formatter_instance = FormatterClass(formatter_kwargs)
+        output["formatter_class"] = FormatterClass.__name__
+        output["formatter_kwargs"] = formatter_kwargs
+
+        # Step 5: create model instance
+        if model is None:
+            ModelClass, model_kwargs = self.default_model_mapping.get(selector, (None, None))
+            if ModelClass is None:
+                message = (
+                    "Default model mapping did not find a match for the"
+                    " selector {}".format(selector)
+                )
+                output['status'] == FAILURE
+                output['failure_message'] = message
+                return output
+        else:
+            ModelClass, model_kwargs = model
+        output["model_class"] = ModelClass.__name__
+        output["model_kwargs"] = model_kwargs
+
+        # Step 6: validate modeling period set.
+        if modeling_period_set is None:
+            message = (
+                "Model is not structural-change capable, so `modeling_period`"
+                " argument must be supplied."
+            )
+            output['status'] == FAILURE
+            output['failure_message'] = message
+            return output
+
+        # Step 7: create split modeled energy trace
+        model_mapping = {
+            modeling_period_label: ModelClass(**model_kwargs)
+            for modeling_period_label, _ in
+            modeling_period_set.iter_modeling_periods()
+        }
+
+        modeled_energy_trace = SplitModeledEnergyTrace(
+            trace, formatter, model_mapping, modeling_period_set)
+
+        modeled_energy_trace.fit(weather_source)
+        output["modeled_energy_trace"] = modeled_energy_trace
+
+        # Step 8: for each modeling period group, create derivatives
+        output["derivatives"] = []
+        for group_label, (_, reporting_period) in \
+                modeling_period_set.iter_modeling_period_groups():
+
+            baseline_label, reporting_label = group_label
+
+            baseline_output = modeled_energy_trace \
+                .fit_outputs[baseline_label]
+            reporting_output = modeled_energy_trace \
+                .fit_outputs[reporting_label]
+
+            baseline_model_success = (baseline_output["status"] == "SUCCESS")
+            reporting_model_success = (reporting_output["status"] == "SUCCESS")
+
+            def _compute_derivative(baseline_label, reporting_label,
+                                    interpretation, derivative_func, kwargs):
+
+                baseline_derivative = None
+                if baseline_model_success:
+                    baseline_derivative = modeled_energy_trace \
+                        .compute_derivative(
+                            baseline_label, derivative_func, **kwargs)
+                    if baseline_derivative is not None:
+                        value, lower, upper, n = derivative[interpretation]
+                        baseline_derivative = Derivative(
+                            baseline_label, value, lower, upper, n
+                        )
+
+                reporting_derivative = None
+                if reporting_model_success:
+                    reporting_derivative = modeled_energy_trace \
+                        .compute_derivative(
+                            reporting_label, derivative_func, **kwargs)
+                    if reporting_derivative is not None:
+                        value, lower, upper, n = derivative[interpretation]
+                        reporting_derivative = Derivative(
+                            reporting_label, value, lower, upper, n
+                        )
+
+                derivative_pair = DerivativePair(
+                    interpretation, baseline_derivative, reporting_derivative
+                )
+                return derivative_pair
+
+            output["derivatives"].extend([
+                _compute_derivative(
+                    baseline_label, reporting_label,
+                    "annualized_weather_normal", annualized_weather_normal,
+                    {
+                        "weather_normal_source": weather_normal_source,
+                    }),
+                _compute_derivative(
+                    baseline_label, reporting_label,
+                    "gross_predicted", gross_predicted,
+                    {
+                        "weather_source": weather_source,
+                        "reporting_period": reporting_period,
+                    }),
+            ])
+
+        output["status"] = SUCCESS
+        return output
+
+
+class Aggregator(object):
+    """
+    Enforces trace interpretation uniformity
+    """
+
+    def __init__(self, func):
+        self.func = func
+
+    def _validate_interpretation(self, derivative_pairs,
+                                 target_interpretation):
+        for d in derivative_pairs:
+            if d.interpretation != self.target_interpretation:
+                message = (
+                    "DerivativePair interpretation ({}) does not match"
+                    " target_interpretation ({})."
+                    .format(d.interpretation, self.target_interpretation)
+                )
+                raise ValueError()
+
+    def aggregate(self, derivative_pairs, target_interpretation):
+        ''' Aggregates derivative pairs
+        '''
+        _validate_interpretation(derivative_pairs, target_interpretation)

--- a/eemeter/ee/meter.py
+++ b/eemeter/ee/meter.py
@@ -24,6 +24,7 @@ from eemeter.ee.derivatives import (
     DerivativePair,
     Derivative
 )
+from eemeter.structures import ZIPCodeSite
 
 from eemeter.io.serializers import deserialize_meter_input
 
@@ -362,7 +363,6 @@ def _change_units(errors, units_from, units_to):
     return (mean*factor, upper*factor, lower*factor, n)
 
 
-
 class EnergyEfficiencyMeterTraceCentric(object):
     ''' Meter for determining energy efficiency derivatives for a single
     traces.
@@ -375,7 +375,8 @@ class EnergyEfficiencyMeterTraceCentric(object):
 
     '''
 
-    def __init__(self, default_model_mapping=None, default_formatter_mapping=None):
+    def __init__(self, default_model_mapping=None,
+                 default_formatter_mapping=None):
 
         if default_formatter_mapping is None:
             daily_formatter = (ModelDataFormatter, {'freq_str': 'D'})
@@ -383,19 +384,23 @@ class EnergyEfficiencyMeterTraceCentric(object):
             default_formatter_mapping = {
                 ('NATURAL_GAS_CONSUMPTION_SUPPLIED', '15T'): daily_formatter,
                 ('ELECTRICITY_CONSUMPTION_SUPPLIED', '15T'): daily_formatter,
-                ('ELECTRICITY_ON_SITE_GENERATION_UNCONSUMED', '15T'): daily_formatter,
+                ('ELECTRICITY_ON_SITE_GENERATION_UNCONSUMED', '15T'):
+                    daily_formatter,
 
                 ('NATURAL_GAS_CONSUMPTION_SUPPLIED', '30T'): daily_formatter,
                 ('ELECTRICITY_CONSUMPTION_SUPPLIED', '30T'): daily_formatter,
-                ('ELECTRICITY_ON_SITE_GENERATION_UNCONSUMED', '30T'): daily_formatter,
+                ('ELECTRICITY_ON_SITE_GENERATION_UNCONSUMED', '30T'):
+                    daily_formatter,
 
                 ('NATURAL_GAS_CONSUMPTION_SUPPLIED', 'H'): daily_formatter,
                 ('ELECTRICITY_CONSUMPTION_SUPPLIED', 'H'): daily_formatter,
-                ('ELECTRICITY_ON_SITE_GENERATION_UNCONSUMED', 'H'): daily_formatter,
+                ('ELECTRICITY_ON_SITE_GENERATION_UNCONSUMED', 'H'):
+                    daily_formatter,
 
                 ('NATURAL_GAS_CONSUMPTION_SUPPLIED', 'D'): daily_formatter,
                 ('ELECTRICITY_CONSUMPTION_SUPPLIED', 'D'): daily_formatter,
-                ('ELECTRICITY_ON_SITE_GENERATION_UNCONSUMED', 'D'): daily_formatter,
+                ('ELECTRICITY_ON_SITE_GENERATION_UNCONSUMED', 'D'):
+                    daily_formatter,
 
                 ('NATURAL_GAS_CONSUMPTION_SUPPLIED', None): billing_formatter,
                 ('ELECTRICITY_CONSUMPTION_SUPPLIED', None): billing_formatter,
@@ -413,19 +418,23 @@ class EnergyEfficiencyMeterTraceCentric(object):
             default_model_mapping = {
                 ('NATURAL_GAS_CONSUMPTION_SUPPLIED', '15T'): seasonal_model,
                 ('ELECTRICITY_CONSUMPTION_SUPPLIED', '15T'): seasonal_model,
-                ('ELECTRICITY_ON_SITE_GENERATION_UNCONSUMED', '15T'): seasonal_model,
+                ('ELECTRICITY_ON_SITE_GENERATION_UNCONSUMED', '15T'):
+                    seasonal_model,
 
                 ('NATURAL_GAS_CONSUMPTION_SUPPLIED', '30T'): seasonal_model,
                 ('ELECTRICITY_CONSUMPTION_SUPPLIED', '30T'): seasonal_model,
-                ('ELECTRICITY_ON_SITE_GENERATION_UNCONSUMED', '30T'): seasonal_model,
+                ('ELECTRICITY_ON_SITE_GENERATION_UNCONSUMED', '30T'):
+                    seasonal_model,
 
                 ('NATURAL_GAS_CONSUMPTION_SUPPLIED', 'H'): seasonal_model,
                 ('ELECTRICITY_CONSUMPTION_SUPPLIED', 'H'): seasonal_model,
-                ('ELECTRICITY_ON_SITE_GENERATION_UNCONSUMED', 'H'): seasonal_model,
+                ('ELECTRICITY_ON_SITE_GENERATION_UNCONSUMED', 'H'):
+                    seasonal_model,
 
                 ('NATURAL_GAS_CONSUMPTION_SUPPLIED', 'D'): seasonal_model,
                 ('ELECTRICITY_CONSUMPTION_SUPPLIED', 'D'): seasonal_model,
-                ('ELECTRICITY_ON_SITE_GENERATION_UNCONSUMED', 'D'): seasonal_model,
+                ('ELECTRICITY_ON_SITE_GENERATION_UNCONSUMED', 'D'):
+                    seasonal_model,
 
                 ('NATURAL_GAS_CONSUMPTION_SUPPLIED', None): billing_model,
                 ('ELECTRICITY_CONSUMPTION_SUPPLIED', None): billing_model,
@@ -448,12 +457,12 @@ class EnergyEfficiencyMeterTraceCentric(object):
             weather data.
         modeling_period_set : eemeter.structures.ModelPeriodSet
             Modeling periods to use in evaluation.
-        formatter : tuple of (eemeter.modeling.Formatter class, kwargs dict), default None
-            Formatter instance for trace and weather data. Used to create input
+        formatter : tuple of (class, dict), default None
+            Formatter for trace and weather data. Used to create input
             for model. If None is provided, will be auto-matched to appropriate
             default formatter.
-        model : tuple of (eemeter.modeling.Model class, kwargs dict), default None
-            Tuple of model instance to use in modeling. If None is provided,
+        model : tuple of (class, dict), default None
+            Model to use in modeling. If None is provided,
             will be auto-matched to appropriate default model.
         weather_source : eemeter.weather.WeatherSource
             Weather source to be used for this meter. Overrides weather source
@@ -468,17 +477,21 @@ class EnergyEfficiencyMeterTraceCentric(object):
             Dictionary of results with the following keys:
 
             - :code:`"status"`: SUCCESS/FAILURE
-            - :code:`"failure_message"`: if FAILURE, message indicates reason for failure, may include traceback
+            - :code:`"failure_message"`: if FAILURE, message indicates reason
+              for failure, may include traceback
             - :code:`"logs"`: list of collected log messages
             - :code:`"model_class"`: Name of model class
-            - :code:`"model_kwargs"`: dict of model keyword arguments (settings)
+            - :code:`"model_kwargs"`: dict of model keyword arguments
+              (settings)
             - :code:`"formatter_class"`: Name of formatter class
-            - :code:`"formatter_kwargs"`: dict of formatter keyword arguments (settings)
+            - :code:`"formatter_kwargs"`: dict of formatter keyword arguments
+              (settings)
             - :code:`"eemeter_version"`: version of the eemeter package
             - :code:`"modeled_energy_trace"`: modeled energy trace
             - :code:`"derivatives"`: derivatives for each interpretation
             - :code:`"weather_source_station"`: Matched weather source station.
-            - :code:`"weather_normal_source_station"`: Matched weather normal source station.
+            - :code:`"weather_normal_source_station"`: Matched weather normal
+              source station.
         '''
 
         SUCCESS = "SUCCESS"
@@ -539,6 +552,7 @@ class EnergyEfficiencyMeterTraceCentric(object):
             output['status'] == FAILURE
             output['failure_message'] = message
             return output
+        site = ZIPCodeSite(zipcode)
 
         # can be blank for models capable of structural change analysis
         modeling_period_set = project.get("modeling_period_set", None)
@@ -588,7 +602,8 @@ class EnergyEfficiencyMeterTraceCentric(object):
 
         # Step 5: create formatter instance
         if formatter is None:
-            FormatterClass, formatter_kwargs = self.default_formatter_mapping.get(selector, (None, None))
+            FormatterClass, formatter_kwargs = self.default_formatter_mapping \
+                .get(selector, (None, None))
             if FormatterClass is None:
                 message = (
                     "Default formatter mapping did not find a match for"
@@ -605,7 +620,8 @@ class EnergyEfficiencyMeterTraceCentric(object):
 
         # Step 6: create model instance
         if model is None:
-            ModelClass, model_kwargs = self.default_model_mapping.get(selector, (None, None))
+            ModelClass, model_kwargs = self.default_model_mapping.get(
+                selector, (None, None))
             if ModelClass is None:
                 message = (
                     "Default model mapping did not find a match for the"

--- a/eemeter/ee/meter.py
+++ b/eemeter/ee/meter.py
@@ -516,10 +516,10 @@ class EnergyEfficiencyMeterTraceCentric(object):
             ("formatter_class", None),
             ("formatter_kwargs", None),
 
-            ("modeled_energy_trace", None),
-            ("derivatives", None),
             ("weather_source_station", None),
             ("weather_normal_source_station", None),
+            ("derivatives", None),
+            ("modeled_energy_trace", None),
         ])
 
         # Step 1: Deserialize input and validate

--- a/eemeter/ee/meter.py
+++ b/eemeter/ee/meter.py
@@ -593,10 +593,13 @@ class EnergyEfficiencyMeterTraceCentric(object):
         if model is None or formatter is None:
             trace_interpretation = trace.interpretation
 
+            print("Trace inferred_freq: {}".format(trace.data.index.inferred_freq))
             trace_frequency = get_approximate_frequency(trace)
+            print("approx freq: {}".format(trace_frequency))
 
             if trace_frequency not in ['H', 'D', '15T', '30T']:
                 trace_frequency = None
+            print("Final freq: {}".format(trace_frequency))
 
             selector = (trace_interpretation, trace_frequency)
 

--- a/eemeter/ee/meter.py
+++ b/eemeter/ee/meter.py
@@ -286,9 +286,13 @@ class EnergyEfficiencyMeter(object):
 
                         if baseline_output is None:
                             baseline_output = (0.0, 0.0, 0.0, 0)
+                        else:
+                            baseline_output = baseline_output[:4]
 
                         if reporting_output is None:
                             reporting_output = (0.0, 0.0, 0.0, 0)
+                        else:
+                            reporting_output = reporting_output[:4]
 
                         baseline_output = _change_units(
                             baseline_output, trace.unit, target_unit)
@@ -690,10 +694,11 @@ class EnergyEfficiencyMeterTraceCentric(object):
                         .compute_derivative(
                             baseline_label, derivative_func, kwargs)
                     if baseline_derivative is not None:
-                        value, lower, upper, n = \
+                        value, lower, upper, n, serialized_demand_fixture = \
                             baseline_derivative[interpretation]
                         baseline_derivative = Derivative(
-                            baseline_label, value, lower, upper, n
+                            baseline_label, value, lower, upper, n,
+                            serialized_demand_fixture
                         )
 
                 reporting_derivative = None
@@ -702,10 +707,11 @@ class EnergyEfficiencyMeterTraceCentric(object):
                         .compute_derivative(
                             reporting_label, derivative_func, kwargs)
                     if reporting_derivative is not None:
-                        value, lower, upper, n = \
+                        value, lower, upper, n, serialized_demand_fixture = \
                             reporting_derivative[interpretation]
                         reporting_derivative = Derivative(
-                            reporting_label, value, lower, upper, n
+                            reporting_label, value, lower, upper, n,
+                            serialized_demand_fixture
                         )
 
                 derivative_pair = DerivativePair(

--- a/eemeter/ee/meter.py
+++ b/eemeter/ee/meter.py
@@ -1,5 +1,4 @@
 import logging
-from collections import namedtuple
 
 from eemeter.processors.interventions import get_modeling_period_set
 from eemeter.processors.location import (
@@ -21,14 +20,10 @@ from eemeter import get_version
 from eemeter.modeling.split import (
     SplitModeledEnergyTrace
 )
-
-DerivativePair = namedtuple('DerivativePair', [
-    'interpretation', 'baseline', 'reporting'
-])
-
-Derivative = namedtuple('Derivative', [
-    'label', 'value', 'lower', 'upper', 'n'
-])
+from eemeter.ee.derivatives import (
+    DerivativePair,
+    Derivative
+)
 
 logger = logging.getLogger(__name__)
 
@@ -661,87 +656,3 @@ class EnergyEfficiencyMeterTraceCentric(object):
 
         output["status"] = SUCCESS
         return output
-
-
-class Aggregator(object):
-    """
-    Enforces trace interpretation uniformity, aggregates according to the
-    aggregation rules supplied.
-    """
-
-    def __init__(self, func,
-                 baseline_default_value=None,
-                 reporting_default_value=None):
-        self.func = func
-        self.baseline_default_value = baseline_default_value
-        self.reporting_default_value = reporting_default_value
-
-    def _validate_interpretation(self, derivative_pairs,
-                                 target_interpretation):
-        for d in derivative_pairs:
-            if d.interpretation != target_interpretation:
-                message = (
-                    "DerivativePair interpretation ({}) does not match"
-                    " target_interpretation ({})."
-                    .format(d.interpretation, target_interpretation)
-                )
-                raise ValueError(message)
-
-    def _get_valid_derivatives(self, derivative_pairs):
-        baseline_derivatives, reporting_derivatives = [], []
-        n_valid = 0
-        n_invalid = 0
-
-        for pair in derivative_pairs:
-            baseline_derivative = pair.baseline
-            if baseline_derivative is None:
-                if self.baseline_default_value is not None:
-                    baseline_derivative = self.baseline_default_value
-
-            reporting_derivative = pair.reporting
-            if reporting_derivative is None:
-                if self.reporting_default_value is not None:
-                    reporting_derivative = self.reporting_default_value
-
-            if baseline_derivative is not None and \
-                    reporting_derivative is not None:
-                baseline_derivatives.append(baseline_derivative)
-                reporting_derivatives.append(reporting_derivative)
-                n_valid += 1
-            else:
-                n_invalid += 1
-
-        return baseline_derivatives, reporting_derivatives, n_valid, n_invalid
-
-    def _aggregate(self, derivatives):
-        if len(derivatives) == 0:
-            return None
-
-        aggregated = derivatives[0]
-        for d in derivatives[1:]:
-            aggregated = self.func(aggregated, d)
-        return aggregated
-
-    def aggregate(self, derivative_pairs, target_interpretation):
-        ''' Aggregates derivative pairs
-
-        Parameters
-        ----------
-        derivative_pairs : list of eemeter.ee.meter.Derivative
-            Derivative pairs to be aggregated.
-        target_interpretation : str
-            Interpretation of derivatives.
-        '''
-        self._validate_interpretation(derivative_pairs, target_interpretation)
-
-        baseline_derivatives, reporting_derivatives, n_valid, n_invalid = \
-            self._get_valid_derivatives(derivative_pairs)
-
-        baseline_aggregation = self._aggregate(baseline_derivatives)
-        reporting_aggregation = self._aggregate(reporting_derivatives)
-
-        aggregated = DerivativePair(
-            target_interpretation, baseline_aggregation, reporting_aggregation
-        )
-
-        return aggregated, n_valid, n_invalid

--- a/eemeter/io/serializers/__init__.py
+++ b/eemeter/io/serializers/__init__.py
@@ -1,6 +1,9 @@
 from .meter_input import (
     deserialize_meter_input,
 )
+from .meter_output import (
+    serialize_derivative_pairs,
+)
 from .trace import (
     ArbitrarySerializer,
     ArbitraryStartSerializer,
@@ -9,8 +12,9 @@ from .trace import (
 
 
 __all__ = (
-    "deserialize_meter_input",
     "ArbitrarySerializer",
     "ArbitraryStartSerializer",
     "ArbitraryEndSerializer",
+    "deserialize_meter_input",
+    "serialize_derivative_pairs",
 )

--- a/eemeter/io/serializers/__init__.py
+++ b/eemeter/io/serializers/__init__.py
@@ -1,3 +1,6 @@
+from .aggregation_input import (
+    deserialize_aggregation_input,
+)
 from .meter_input import (
     deserialize_meter_input,
 )
@@ -16,6 +19,7 @@ __all__ = (
     "ArbitrarySerializer",
     "ArbitraryStartSerializer",
     "ArbitraryEndSerializer",
+    "deserialize_aggregation_input",
     "deserialize_meter_input",
     "serialize_derivative_pairs",
     "serialize_split_modeled_energy_trace",

--- a/eemeter/io/serializers/__init__.py
+++ b/eemeter/io/serializers/__init__.py
@@ -3,6 +3,7 @@ from .meter_input import (
 )
 from .meter_output import (
     serialize_derivative_pairs,
+    serialize_split_modeled_energy_trace,
 )
 from .trace import (
     ArbitrarySerializer,
@@ -17,4 +18,5 @@ __all__ = (
     "ArbitraryEndSerializer",
     "deserialize_meter_input",
     "serialize_derivative_pairs",
+    "serialize_split_modeled_energy_trace",
 )

--- a/eemeter/io/serializers/__init__.py
+++ b/eemeter/io/serializers/__init__.py
@@ -1,0 +1,16 @@
+from .meter_input import (
+    deserialize_meter_input,
+)
+from .trace import (
+    ArbitrarySerializer,
+    ArbitraryStartSerializer,
+    ArbitraryEndSerializer,
+)
+
+
+__all__ = (
+    "deserialize_meter_input",
+    "ArbitrarySerializer",
+    "ArbitraryStartSerializer",
+    "ArbitraryEndSerializer",
+)

--- a/eemeter/io/serializers/__init__.py
+++ b/eemeter/io/serializers/__init__.py
@@ -5,6 +5,7 @@ from .meter_input import (
     deserialize_meter_input,
 )
 from .meter_output import (
+    serialize_derivative_pair,
     serialize_derivative_pairs,
     serialize_split_modeled_energy_trace,
 )
@@ -21,6 +22,7 @@ __all__ = (
     "ArbitraryEndSerializer",
     "deserialize_aggregation_input",
     "deserialize_meter_input",
+    "serialize_derivative_pair",
     "serialize_derivative_pairs",
     "serialize_split_modeled_energy_trace",
 )

--- a/eemeter/io/serializers/aggregation_input.py
+++ b/eemeter/io/serializers/aggregation_input.py
@@ -1,0 +1,191 @@
+from eemeter.ee.derivatives import Derivative, DerivativePair
+
+def deserialize_aggregation_input(aggregation_input):
+
+    # verify type
+    type_ = aggregation_input.get('type', None)
+    if type_ is None:
+        return {
+            'error': 'Serialization "type" must be provided for'
+            ' aggregation_input.'
+        }
+
+    # switch on type
+    if type_ == 'BASIC_AGGREGATION':
+        return _deserialize_basic_aggregation(aggregation_input)
+    else:
+        return {
+            'error': 'Serialization type "{}" not recognized.'.format(type_)
+        }
+
+
+def _get_key_or_error(serialized, key_name, type_):
+
+    value = serialized.get(key_name, None)
+
+    error = None
+    if value is None:
+        error = {
+            'error': (
+                'For serialization type "{}",'
+                ' key "{}" must be provided.'
+                .format(type_, key_name)
+            )
+        }
+
+    return value, error
+
+
+def _deserialize_basic_aggregation(aggregation_input):
+    type_ = 'BASIC_AGGREGATION'
+
+    # check for "aggregation_interpretation" key
+    aggregation_interpretation, error = _get_key_or_error(
+        aggregation_input, "aggregation_interpretation", type_)
+    if aggregation_interpretation is None:
+        return error
+
+    # check for "trace_interpretation" key
+    trace_interpretation, error = _get_key_or_error(
+        aggregation_input, "trace_interpretation", type_)
+    if trace_interpretation is None:
+        return error
+
+    # check for "derivative_interpretation" key
+    derivative_interpretation, error = _get_key_or_error(
+        aggregation_input, "derivative_interpretation", type_)
+    if derivative_interpretation is None:
+        return error
+
+    # check for "derivatives" key
+    derivatives, error = _get_key_or_error(
+        aggregation_input, "derivatives", type_)
+    if derivatives is None:
+        return error
+
+    # check for baseline default value
+    baseline_default_value = aggregation_input.get("baseline_default_value")
+    if baseline_default_value is None:
+        baseline_default = None
+    else:
+        baseline_default = _deserialize_default_value(baseline_default_value)
+        if "error" in baseline_default:
+            return baseline_default
+
+    # check for reporting default value
+    reporting_default_value = aggregation_input.get("reporting_default_value")
+    if reporting_default_value is None:
+        reporting_default = None
+    else:
+        reporting_default = _deserialize_default_value(reporting_default_value)
+        if "error" in reporting_default:
+            return reporting_default
+
+    # check for "derivatives" key
+    derivatives, error = _get_key_or_error(
+        aggregation_input, "derivatives", type_)
+    if derivatives is None:
+        return error
+
+    derivative_pairs = _deserialize_derivatives(derivatives)
+    if "error" in derivative_pairs:
+        return derivative_pairs
+
+    return {
+        "aggregation_interpretation": aggregation_interpretation,
+        "trace_interpretation": trace_interpretation,
+        "derivative_interpretation": derivative_interpretation,
+        "baseline_default_value": baseline_default,
+        "reporting_default_value": reporting_default,
+        "derivative_pairs": derivative_pairs,
+    }
+
+
+def _deserialize_default_value(default_value):
+    # verify type
+    type_ = default_value.get('type', None)
+    if type_ is None:
+        return {
+            'error': 'Serialization "type" must be provided for'
+            ' baseline_default_value or reporting_default_value.'
+        }
+
+    # switch on type
+    if type_ == 'SIMPLE_DEFAULT':
+        return _deserialize_simple_default(default_value)
+    else:
+        return {
+            'error': 'Serialization type "{}" not recognized.'.format(type_)
+        }
+
+def _deserialize_simple_default(default_value):
+    try:
+        return Derivative(
+            None,
+            default_value["value"],
+            default_value["lower"],
+            default_value["upper"],
+            default_value["n"],
+            None
+        )
+    except:
+        return {
+            "error": "Missing key in default_value serialization."
+        }
+
+
+def _deserialize_derivatives(derivatives):
+
+    # verify type
+    type_ = derivatives.get('type', None)
+    if type_ is None:
+        return {
+            'error': 'Serialization "type" must be provided for'
+            ' derivatives.'
+        }
+
+    # switch on type
+    if type_ == 'DERIVATIVE_PAIRS':
+        return _deserialize_derivative_pairs(derivatives)
+    else:
+        return {
+            'error': 'Serialization type "{}" not recognized.'.format(type_)
+        }
+
+
+def _deserialize_derivative_pairs(derivatives):
+
+    # check for "derivative_interpretation" key
+    derivative_pairs, error = _get_key_or_error(
+        derivatives, "derivative_pairs", "DERIVATIVE_PAIRS")
+    if derivative_pairs is None:
+        return error
+
+    try:
+        return [
+            DerivativePair(
+                pair["derivative_interpretation"],
+                pair["trace_interpretation"],
+                pair["unit"],
+                Derivative(
+                    None,
+                    pair["baseline_value"],
+                    pair["baseline_lower"],
+                    pair["baseline_upper"],
+                    pair["baseline_n"],
+                    None
+                ),
+                Derivative(
+                    None,
+                    pair["reporting_value"],
+                    pair["reporting_lower"],
+                    pair["reporting_upper"],
+                    pair["reporting_n"],
+                    None
+                ),
+            ) for pair in derivative_pairs
+        ]
+    except KeyError:
+        return {
+            "error": "Missing key in derivative_pair serialization."
+        }

--- a/eemeter/io/serializers/aggregation_input.py
+++ b/eemeter/io/serializers/aggregation_input.py
@@ -1,5 +1,6 @@
 from eemeter.ee.derivatives import Derivative, DerivativePair
 
+
 def deserialize_aggregation_input(aggregation_input):
 
     # verify type
@@ -164,6 +165,7 @@ def _deserialize_derivative_pairs(derivatives):
     try:
         return [
             DerivativePair(
+                pair["label"],
                 pair["derivative_interpretation"],
                 pair["trace_interpretation"],
                 pair["unit"],

--- a/eemeter/io/serializers/meter_input.py
+++ b/eemeter/io/serializers/meter_input.py
@@ -157,6 +157,7 @@ def _deserialize_simple_project(project):
             )
         }
 
+
 def _deserialize_project_with_single_model_period_group(project):
 
     # check for "zipcode" key
@@ -191,6 +192,7 @@ def _deserialize_project_with_single_model_period_group(project):
         }
     }
 
+
 def _deserialize_single_modeling_period_group(modeling_period_group):
 
     # check for "baseline_period" key
@@ -203,11 +205,11 @@ def _deserialize_single_modeling_period_group(modeling_period_group):
             )
         }
     else:
-        start_date=baseline_period.get("start", None)
+        start_date = baseline_period.get("start", None)
         if start_date is not None:
             start_date = dateutil.parser.parse(start_date)
 
-        end_date=baseline_period.get("end", None)
+        end_date = baseline_period.get("end", None)
         if end_date is not None:
             end_date = dateutil.parser.parse(end_date)
 
@@ -227,11 +229,11 @@ def _deserialize_single_modeling_period_group(modeling_period_group):
             )
         }
     else:
-        start_date=reporting_period.get("start", None)
+        start_date = reporting_period.get("start", None)
         if start_date is not None:
             start_date = dateutil.parser.parse(start_date)
 
-        end_date=reporting_period.get("end", None)
+        end_date = reporting_period.get("end", None)
         if end_date is not None:
             end_date = dateutil.parser.parse(end_date)
 

--- a/eemeter/io/serializers/meter_input.py
+++ b/eemeter/io/serializers/meter_input.py
@@ -1,0 +1,256 @@
+from .trace import (
+    ArbitrarySerializer,
+    ArbitraryStartSerializer,
+    ArbitraryEndSerializer,
+)
+from eemeter.structures import (
+    EnergyTrace,
+    ModelingPeriod,
+    ModelingPeriodSet
+)
+
+import dateutil.parser
+
+
+def deserialize_meter_input(meter_input):
+
+    # verify type
+    type_ = meter_input.get('type', None)
+    if type_ is None:
+        return {
+            'error': 'Serialization "type" must be provided for meter_input.'
+        }
+
+    # switch on type
+    if type_ == 'SINGLE_TRACE_SIMPLE_PROJECT':
+        return _deserialize_single_trace_simple_project(meter_input)
+    else:
+        return {
+            'error': 'Serialization type "{}" not recognized.'.format(type_)
+        }
+
+
+def _deserialize_single_trace_simple_project(meter_input):
+
+    # check for "trace" key
+    single_trace = meter_input.get('trace', None)
+    if single_trace is None:
+        return {
+            'error': (
+                'For serialization type "SINGLE_TRACE_SIMPLE_PROJECT",'
+                ' key "trace" must be provided.'
+            )
+        }
+
+    # check for "project" key
+    simple_project = meter_input.get('project', None)
+    if simple_project is None:
+        return {
+            'error': (
+                'For serialization type "SINGLE_TRACE_SIMPLE_PROJECT",'
+                ' key "project" must be provided.'
+            )
+        }
+
+    trace = _deserialize_single_trace(single_trace)
+    if "error" in trace:
+        return trace
+
+    project = _deserialize_simple_project(simple_project)
+    if "error" in project:
+        return project
+
+    return {
+        "trace": trace["trace"],
+        "project": project["project"],
+    }
+
+
+def _deserialize_single_trace(trace):
+
+    # verify type
+    type_ = trace.get('type', None)
+    if type_ is None:
+        return {
+            'error': 'Serialization "type" not given for trace.'
+        }
+
+    # check for "interpretation" key
+    interpretation = trace.get('interpretation', None)
+    if interpretation is None:
+        return {
+            'error': (
+                'Trace serializations must provide key "interpretation".'
+            )
+        }
+
+    # check for "unit" key
+    unit = trace.get('unit', None)
+    if unit is None:
+        return {
+            'error': (
+                'Trace serializations must provide key "unit".'
+            )
+        }
+
+    # check for "records" key
+    records = trace.get('records', None)
+    if records is None:
+        return {
+            'error': (
+                'Trace serializations must provide key "records".'
+            )
+        }
+
+    # switch on type
+    if type_ == 'ARBITRARY':
+        return {
+            "trace": EnergyTrace(
+                interpretation=interpretation,
+                unit=unit,
+                records=records,
+                serializer=ArbitrarySerializer(parse_dates=True)
+            )
+        }
+    elif type_ == 'ARBITRARY_START':
+        return {
+            "trace": EnergyTrace(
+                interpretation=interpretation,
+                unit=unit,
+                records=records,
+                serializer=ArbitraryStartSerializer(parse_dates=True)
+            )
+        }
+    elif type_ == 'ARBITRARY_END':
+        return {
+            "trace": EnergyTrace(
+                interpretation=interpretation,
+                unit=unit,
+                records=records,
+                serializer=ArbitraryEndSerializer(parse_dates=True)
+            )
+        }
+    else:
+        return {
+            'error': (
+                'Serialization type "{}" not recognized for trace.'
+                .format(type_)
+            )
+        }
+
+
+def _deserialize_simple_project(project):
+    # verify type
+    type_ = project.get('type', None)
+    if type_ is None:
+        return {
+            'error': 'Serialization "type" not given for project.'
+        }
+
+    if type_ == "PROJECT_WITH_SINGLE_MODELING_PERIOD_GROUP":
+        return _deserialize_project_with_single_model_period_group(project)
+    else:
+        return {
+            'error': (
+                'Serialization type "{}" not recognized for project.'
+                .format(type_)
+            )
+        }
+
+def _deserialize_project_with_single_model_period_group(project):
+
+    # check for "zipcode" key
+    zipcode = project.get('zipcode', None)
+    if zipcode is None:
+        return {
+            'error': (
+                'Project serializations must provide key "zipcode".'
+            )
+        }
+
+    # check for "modeling_period_group" key
+    modeling_period_group = project.get('modeling_period_group', None)
+    if modeling_period_group is None:
+        return {
+            'error': (
+                'Project serializations must provide key'
+                ' "modeling_period_group".'
+            )
+        }
+
+    modeling_period_set = _deserialize_single_modeling_period_group(
+        modeling_period_group
+    )
+    if "error" in modeling_period_set:
+        return modeling_period_set
+
+    return {
+        "project": {
+            "zipcode": zipcode,
+            "modeling_period_set": modeling_period_set["modeling_period_set"],
+        }
+    }
+
+def _deserialize_single_modeling_period_group(modeling_period_group):
+
+    # check for "baseline_period" key
+    baseline_period = modeling_period_group.get('baseline_period', None)
+    if baseline_period is None:
+        return {
+            'error': (
+                'Project serializations must provide key'
+                ' "baseline_period".'
+            )
+        }
+    else:
+        start_date=baseline_period.get("start", None)
+        if start_date is not None:
+            start_date = dateutil.parser.parse(start_date)
+
+        end_date=baseline_period.get("end", None)
+        if end_date is not None:
+            end_date = dateutil.parser.parse(end_date)
+
+        baseline = ModelingPeriod(
+            "BASELINE",
+            start_date,
+            end_date
+        )
+
+    # check for "reporting_period" key
+    reporting_period = modeling_period_group.get('reporting_period', None)
+    if reporting_period is None:
+        return {
+            'error': (
+                'Project serializations must provide key'
+                ' "reporting_period".'
+            )
+        }
+    else:
+        start_date=reporting_period.get("start", None)
+        if start_date is not None:
+            start_date = dateutil.parser.parse(start_date)
+
+        end_date=reporting_period.get("end", None)
+        if end_date is not None:
+            end_date = dateutil.parser.parse(end_date)
+
+        reporting = ModelingPeriod(
+            "REPORTING",
+            start_date,
+            end_date
+        )
+
+    modeling_periods = {
+        "baseline": baseline,
+        "reporting": reporting,
+    }
+
+    grouping = [
+        ("baseline", "reporting"),
+    ]
+
+    mps = ModelingPeriodSet(modeling_periods, grouping)
+    return {
+        "modeling_period_set": mps
+    }

--- a/eemeter/io/serializers/meter_output.py
+++ b/eemeter/io/serializers/meter_output.py
@@ -4,7 +4,7 @@ def serialize_derivative_pairs(derivative_pairs):
     return [
         OrderedDict([
             ("interpretation", interpretation),
-            ("baseline", None if baseline is None else OrderedDict([
+            ("baseline", OrderedDict([
                 ("label", baseline.label),
                 ("value", baseline.value),
                 ("lower", baseline.lower),
@@ -13,7 +13,7 @@ def serialize_derivative_pairs(derivative_pairs):
                 ("demand_fixture",
                  baseline.serialized_demand_fixture),
             ])),
-            ("reporting", None if reporting is None else OrderedDict([
+            ("reporting", OrderedDict([
                 ("label", reporting.label),
                 ("value", reporting.value),
                 ("lower", reporting.lower),
@@ -29,6 +29,7 @@ def serialize_derivative_pairs(derivative_pairs):
 
 def serialize_split_modeled_energy_trace(modeled_trace):
     serialized = OrderedDict([
+        ("type", "SPLIT_MODELED_ENERGY_TRACE"),
         ("fits", _serialize_fit_outputs(modeled_trace.fit_outputs)),
         ("modeling_period_set", serialize_modeling_period_set(modeled_trace.modeling_period_set)),
     ])

--- a/eemeter/io/serializers/meter_output.py
+++ b/eemeter/io/serializers/meter_output.py
@@ -10,6 +10,8 @@ def serialize_derivative_pairs(derivative_pairs):
                 ("lower", baseline.lower),
                 ("upper", baseline.upper),
                 ("n", baseline.n),
+                ("demand_fixture",
+                 baseline.serialized_demand_fixture),
             ])),
             ("reporting", None if reporting is None else OrderedDict([
                 ("label", reporting.label),
@@ -17,6 +19,8 @@ def serialize_derivative_pairs(derivative_pairs):
                 ("lower", reporting.lower),
                 ("upper", reporting.upper),
                 ("n", reporting.n),
+                ("demand_fixture",
+                 reporting.serialized_demand_fixture),
             ])),
         ])
         for interpretation, baseline, reporting in derivative_pairs

--- a/eemeter/io/serializers/meter_output.py
+++ b/eemeter/io/serializers/meter_output.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 
+
 def serialize_derivative_pairs(derivative_pairs):
     return [ serialize_derivative_pair(dp) for dp in derivative_pairs]
 

--- a/eemeter/io/serializers/meter_output.py
+++ b/eemeter/io/serializers/meter_output.py
@@ -37,11 +37,11 @@ def _serialize_fit_outputs(fit_outputs):
         (mp_label, OrderedDict([
             ("status", output.get("status", None)),
             ("traceback", output.get("traceback", None)),
-            ("input_data", output.get("input_data", None)),
             ("start_date", None if output.get("start_date", None) is None else output.get("start_date").isoformat()),
             ("end_date", None if output.get("end_date", None) is None else output.get("end_date").isoformat()),
             ("n_rows", output.get("n_rows", None)),
             ("model_fit", _serialize_model_fit(output.get("model_fit", None))),
+            ("input_data", output.get("input_data", None)),
         ]))
         for mp_label, output in sorted(fit_outputs.items(), key=lambda x: x[0])
     ])

--- a/eemeter/io/serializers/meter_output.py
+++ b/eemeter/io/serializers/meter_output.py
@@ -1,0 +1,34 @@
+from collections import OrderedDict
+
+def serialize_derivative_pairs(derivative_pairs):
+    serialized = []
+    for interpretation, baseline, reporting in derivative_pairs:
+
+        if baseline is not None:
+            baseline_serialized = OrderedDict([
+                ("label", baseline.label),
+                ("value", baseline.value),
+                ("lower", baseline.lower),
+                ("upper", baseline.upper),
+                ("n", baseline.n),
+            ])
+        else:
+            baseline_serialized = None
+
+        if reporting is not None:
+            reporting_serialized = OrderedDict([
+                ("label", reporting.label),
+                ("value", reporting.value),
+                ("lower", reporting.lower),
+                ("upper", reporting.upper),
+                ("n", reporting.n),
+            ])
+        else:
+            reporting_serialized = None
+
+        serialized.append(OrderedDict([
+            ("interpretation", interpretation),
+            ("baseline", baseline_serialized),
+            ("reporting", reporting_serialized),
+        ]))
+    return serialized

--- a/eemeter/io/serializers/meter_output.py
+++ b/eemeter/io/serializers/meter_output.py
@@ -3,7 +3,8 @@ from collections import OrderedDict
 def serialize_derivative_pairs(derivative_pairs):
     return [
         OrderedDict([
-            ("interpretation", interpretation),
+            ("derivative_interpretation", d_interp),
+            ("trace_interpretation", t_interp),
             ("unit", unit),
             ("baseline", OrderedDict([
                 ("label", baseline.label),
@@ -24,7 +25,7 @@ def serialize_derivative_pairs(derivative_pairs):
                  reporting.serialized_demand_fixture),
             ])),
         ])
-        for interpretation, unit, baseline, reporting in derivative_pairs
+        for d_interp, t_interp, unit, baseline, reporting in derivative_pairs
     ]
 
 

--- a/eemeter/io/serializers/meter_output.py
+++ b/eemeter/io/serializers/meter_output.py
@@ -1,8 +1,13 @@
 from collections import OrderedDict
 
 def serialize_derivative_pairs(derivative_pairs):
-    return [
-        OrderedDict([
+    return [ serialize_derivative_pair(dp) for dp in derivative_pairs]
+
+
+def serialize_derivative_pair(derivative_pair):
+    label, d_interp, t_interp, unit, baseline, reporting = derivative_pair
+    return OrderedDict([
+            ("label", label),
             ("derivative_interpretation", d_interp),
             ("trace_interpretation", t_interp),
             ("unit", unit),
@@ -25,8 +30,6 @@ def serialize_derivative_pairs(derivative_pairs):
                  reporting.serialized_demand_fixture),
             ])),
         ])
-        for d_interp, t_interp, unit, baseline, reporting in derivative_pairs
-    ]
 
 
 def serialize_split_modeled_energy_trace(modeled_trace):

--- a/eemeter/io/serializers/meter_output.py
+++ b/eemeter/io/serializers/meter_output.py
@@ -4,6 +4,7 @@ def serialize_derivative_pairs(derivative_pairs):
     return [
         OrderedDict([
             ("interpretation", interpretation),
+            ("unit", unit),
             ("baseline", OrderedDict([
                 ("label", baseline.label),
                 ("value", baseline.value),
@@ -23,7 +24,7 @@ def serialize_derivative_pairs(derivative_pairs):
                  reporting.serialized_demand_fixture),
             ])),
         ])
-        for interpretation, baseline, reporting in derivative_pairs
+        for interpretation, unit, baseline, reporting in derivative_pairs
     ]
 
 

--- a/eemeter/io/serializers/trace.py
+++ b/eemeter/io/serializers/trace.py
@@ -1,7 +1,9 @@
-import pandas as pd
-import numpy as np
-import pytz
 import warnings
+
+import dateutil.parser
+import numpy as np
+import pandas as pd
+import pytz
 
 
 class BaseSerializer(object):
@@ -9,6 +11,9 @@ class BaseSerializer(object):
     sort_key = None
     required_fields = []
     datetime_fields = []
+
+    def __init__(self, parse_dates=False):
+        self.parse_dates = parse_dates
 
     def _sort_records(self, records):
         if self.sort_key is None:
@@ -34,6 +39,9 @@ class BaseSerializer(object):
             dts, values, estimateds = [], [], []
         else:
             dts, values, estimateds = zip(*validated_tuples)
+
+        if self.parse_dates:
+            dts = [dateutil.parser.parse(dt) for dt in dts]
 
         df = pd.DataFrame(
             {"value": values, "estimated": estimateds},
@@ -80,7 +88,10 @@ class BaseSerializer(object):
 
         # make sure dates/datetimes are tz aware
         for field in self.datetime_fields:
-            dt = record[field]
+            if self.parse_dates:
+                dt = dateutil.parser.parse(record[field])
+            else:
+                dt = record[field]
             if dt.tzinfo is None or dt.tzinfo.utcoffset(dt) is None:
                 message = (
                     'Record field ("{}": {}) is not timezone aware:\n{}'

--- a/eemeter/io/serializers/trace.py
+++ b/eemeter/io/serializers/trace.py
@@ -45,7 +45,7 @@ class BaseSerializer(object):
 
         df = pd.DataFrame(
             {"value": values, "estimated": estimateds},
-            index=pd.DatetimeIndex(dts),
+            index=pd.DatetimeIndex(dts).tz_localize(pytz.UTC),
             columns=["value", "estimated"],
         )
         df.value = df.value.astype(float)

--- a/eemeter/io/serializers/trace.py
+++ b/eemeter/io/serializers/trace.py
@@ -43,9 +43,13 @@ class BaseSerializer(object):
         if self.parse_dates:
             dts = [dateutil.parser.parse(dt) for dt in dts]
 
+        index = pd.DatetimeIndex(dts)
+        if index.shape[0] > 0:
+            index = index.tz_convert(pytz.UTC)
+
         df = pd.DataFrame(
             {"value": values, "estimated": estimateds},
-            index=pd.DatetimeIndex(dts).tz_localize(pytz.UTC),
+            index=index,
             columns=["value", "estimated"],
         )
         df.value = df.value.astype(float)

--- a/eemeter/modeling/formatters.py
+++ b/eemeter/modeling/formatters.py
@@ -50,9 +50,6 @@ class FormatterBase(object):
             "n_rows": self._get_n_rows(input_data),
         }
 
-    def serialize_demand_fixture(self, demand_fixture_data):
-        pass
-
 
 class ModelDataFormatter(FormatterBase):
     ''' Formatter for model data of known or predictable frequency.
@@ -158,6 +155,12 @@ class ModelDataFormatter(FormatterBase):
                 ("tempF", row.tempF if pd.notnull(row.tempF) else None),
             ]))
             for start, row in input_data.iterrows()
+        ])
+
+    def serialize_demand_fixture(self, demand_fixture_data):
+        return OrderedDict([
+            (i.isoformat(), row.tempF)
+            for i, row in demand_fixture_data.iterrows()
         ])
 
 class ModelDataBillingFormatter(FormatterBase):
@@ -328,4 +331,10 @@ formatter.create_input(energy_trace, weather_source)
             ]))
             for (start, energy), (p, group) in
                 zip(trace_data.iteritems(), temp_data.groupby(level="period"))
+        ])
+
+    def serialize_demand_fixture(self, demand_fixture_data):
+        return OrderedDict([
+            (i.isoformat(), row.tempF)
+            for i, row in demand_fixture_data.iterrows()
         ])

--- a/eemeter/modeling/formatters.py
+++ b/eemeter/modeling/formatters.py
@@ -50,6 +50,9 @@ class FormatterBase(object):
             "n_rows": self._get_n_rows(input_data),
         }
 
+    def serialize_demand_fixture(self, demand_fixture_data):
+        pass
+
 
 class ModelDataFormatter(FormatterBase):
     ''' Formatter for model data of known or predictable frequency.

--- a/eemeter/modeling/models/__init__.py
+++ b/eemeter/modeling/models/__init__.py
@@ -1,3 +1,7 @@
 from eemeter.modeling.models.seasonal import SeasonalElasticNetCVModel
+from eemeter.modeling.models.billing import BillingElasticNetCVModel
 
-__all__ = ['SeasonalElasticNetCVModel', ]
+__all__ = (
+    'SeasonalElasticNetCVModel',
+    'BillingElasticNetCVModel',
+)

--- a/eemeter/modeling/models/billing.py
+++ b/eemeter/modeling/models/billing.py
@@ -46,6 +46,8 @@ class BillingElasticNetCVModel():
         elif 'daily' in temperature_data.index.names:
             cdd = np.maximum((temperature_data - self.cooling_base_temp)
                              .groupby(level='period').sum()[0], 0.0)
+        else:
+            cdd = []
         return cdd
 
     def _hdd(self, temperature_data):
@@ -55,6 +57,8 @@ class BillingElasticNetCVModel():
         elif 'daily' in temperature_data.index.names:
             hdd = np.maximum((self.heating_base_temp - temperature_data)
                              .groupby(level='period').sum()[0], 0.0)
+        else:
+            hdd = []
         return hdd
 
     def fit(self, input_data):

--- a/eemeter/modeling/split.py
+++ b/eemeter/modeling/split.py
@@ -115,7 +115,7 @@ class SplitModeledEnergyTrace(object):
                         .format(model, self.trace.interpretation,
                                 modeling_period_label)
                     )
-                    outputs["model_filt"].update(model_fit)
+                    outputs["model_fit"].update(model_fit)
                     outputs.update({
                         "status": "SUCCESS",
                     })

--- a/eemeter/modeling/split.py
+++ b/eemeter/modeling/split.py
@@ -66,6 +66,7 @@ class SplitModeledEnergyTrace(object):
                 "start_date": None,
                 "end_date": None,
                 "n_rows": None,
+                "model_fit": {},
             }
 
             # attempt to create input data
@@ -114,9 +115,9 @@ class SplitModeledEnergyTrace(object):
                         .format(model, self.trace.interpretation,
                                 modeling_period_label)
                     )
+                    outputs["model_filt"].update(model_fit)
                     outputs.update({
                         "status": "SUCCESS",
-                        "model_fit": model_fit,
                     })
 
             self.fit_outputs[modeling_period_label] = outputs

--- a/eemeter/modeling/split.py
+++ b/eemeter/modeling/split.py
@@ -146,7 +146,7 @@ class SplitModeledEnergyTrace(object):
                 demand_fixture_data, params)
 
     def compute_derivative(self, modeling_period_label, derivative_callable,
-                           **kwargs):
+                           derivative_callable_kwargs):
         ''' Compute a modeling derivative for this modeling period.
 
         Parameters
@@ -160,7 +160,7 @@ class SplitModeledEnergyTrace(object):
 
                 >>> derivative_callable(formatter, model, **kwargs)
 
-        **kwargs
+        derivative_callable_kwargs : dict
             Arbitrary keyword arguments to be passed to the derviative callable
         '''
 
@@ -172,7 +172,8 @@ class SplitModeledEnergyTrace(object):
         model = self.model_mapping[modeling_period_label]
 
         try:
-            derivative = derivative_callable(self.formatter, model, **kwargs)
+            derivative = derivative_callable(self.formatter, model,
+                                             **derivative_callable_kwargs)
         except Exception:
             logger.exception("Derivative computation failed.")
             return None

--- a/eemeter/processors/dispatchers.py
+++ b/eemeter/processors/dispatchers.py
@@ -85,8 +85,7 @@ def get_energy_modeling_dispatches(modeling_period_set, trace_set):
             )
             continue
 
-        frequency = _get_approximate_frequency(
-                logger, trace.data, trace_label)
+        frequency = get_approximate_frequency(trace)
 
         if frequency not in ['H', 'D', '15T', '30T']:
             frequency = None
@@ -133,24 +132,24 @@ def get_energy_modeling_dispatches(modeling_period_set, trace_set):
     return dispatches
 
 
-def _get_approximate_frequency(logger, data, trace_label):
+def get_approximate_frequency(trace):
 
-    if data is None:
+    if trace.data is None:
         logger.info(
             "Could not determine frequency:"
-            " EnergyTrace '{}' is placeholder instance."
-            .format(trace_label)
+            " {} is placeholder instance."
+            .format(trace)
         )
         return None
 
     def _log_success(freq):
         logger.info(
-            "Determined frequency of '{}' for EnergyTrace '{}'."
-            .format(freq, trace_label)
+            "Determined frequency of '{}' for {}."
+            .format(freq, trace)
         )
 
     try:
-        freq = pd.infer_freq(data.index)
+        freq = pd.infer_freq(trace.data.index)
     except ValueError:  # too few data points
         logger.error("Could not determine frequency - too few points.")
         return None
@@ -163,7 +162,7 @@ def _get_approximate_frequency(logger, data, trace_label):
     # strategy: try two groups of 5 dates
     for i in range(0, 9, 5):
         try:
-            freq = pd.infer_freq(data.index[i:i+5])
+            freq = pd.infer_freq(trace.data.index[i:i+5])
         except ValueError:
             pass
         else:

--- a/eemeter/processors/location.py
+++ b/eemeter/processors/location.py
@@ -10,13 +10,13 @@ from eemeter.weather.tmy3 import TMY3WeatherSource
 logger = logging.getLogger(__name__)
 
 
-def get_weather_source(project):
+def get_weather_source(site):
     ''' Finds most relevant WeatherSource given project site.
 
     Parameters
     ----------
-    project : eemeter.structures.Project
-        Project for which to find weather source data.
+    site : eemeter.structures.ZIPCodeSite
+        Site to match to weather source data.
 
     Returns
     -------
@@ -25,7 +25,7 @@ def get_weather_source(project):
         project ZIP code, if available.
     '''
 
-    zipcode = project.site.zipcode
+    zipcode = site.zipcode
     station = zipcode_to_usaf_station(zipcode)
 
     if station is None:
@@ -54,13 +54,13 @@ def get_weather_source(project):
     return weather_source
 
 
-def get_weather_normal_source(project):
+def get_weather_normal_source(site):
     ''' Finds most relevant WeatherSource given project site.
 
     Parameters
     ----------
-    project : eemeter.structures.Project
-        Project for which to find weather source data.
+    site : eemeter.structures.ZIPCodeSite
+        Site to match to weather source data.
 
     Returns
     -------
@@ -69,7 +69,7 @@ def get_weather_normal_source(project):
         project ZIP code, if available.
     '''
 
-    zipcode = project.site.zipcode
+    zipcode = site.zipcode
     station = zipcode_to_tmy3_station(zipcode)
 
     if station is None:

--- a/eemeter/structures/trace.py
+++ b/eemeter/structures/trace.py
@@ -180,8 +180,8 @@ class EnergyTrace(object):
             )
         else:
             return (
-                "EnergyTrace(interpretation={}, unit={}, data={})"
-                .format(self.interpretation, self.unit, self.data)
+                "EnergyTrace(interpretation={}, unit={}, data=pd.Dataframe({}))"
+                .format(self.interpretation, self.unit, self.data.shape)
             )
 
     def _set_interpretation(self, interpretation):

--- a/eemeter/structures/trace.py
+++ b/eemeter/structures/trace.py
@@ -180,7 +180,8 @@ class EnergyTrace(object):
             )
         else:
             return (
-                "EnergyTrace(interpretation={}, unit={}, data=pd.Dataframe({}))"
+                "EnergyTrace(interpretation={}, unit={},"
+                " data=pandas.Dataframe({}))"
                 .format(self.interpretation, self.unit, self.data.shape)
             )
 

--- a/tests/ee/test_aggregator.py
+++ b/tests/ee/test_aggregator.py
@@ -14,6 +14,7 @@ def aggregation_input():
             "type": "DERIVATIVE_PAIRS",
             "derivative_pairs": [
                 {
+                    "label": "1",
                     "derivative_interpretation": "annualized_weather_normal",
                     "trace_interpretation": "NATURAL_GAS_CONSUMPTION_SUPPLIED",
                     "unit": "therm",
@@ -27,6 +28,7 @@ def aggregation_input():
                     "reporting_n": 5,
                 },
                 {
+                    "label": "2",
                     "derivative_interpretation": "annualized_weather_normal",
                     "trace_interpretation": "NATURAL_GAS_CONSUMPTION_SUPPLIED",
                     "unit": "therm",
@@ -69,6 +71,7 @@ def aggregation_input_single():
             "type": "DERIVATIVE_PAIRS",
             "derivative_pairs": [
                 {
+                    "label": "1",
                     "derivative_interpretation": "annualized_weather_normal",
                     "trace_interpretation": "NATURAL_GAS_CONSUMPTION_SUPPLIED",
                     "unit": "therm",
@@ -97,6 +100,7 @@ def aggregation_input_mixed_derivative_interpretation():
             "type": "DERIVATIVE_PAIRS",
             "derivative_pairs": [
                 {
+                    "label": "1",
                     "derivative_interpretation": "annualized_weather_normal",
                     "trace_interpretation": "NATURAL_GAS_CONSUMPTION_SUPPLIED",
                     "unit": "therm",
@@ -110,6 +114,7 @@ def aggregation_input_mixed_derivative_interpretation():
                     "reporting_n": 5,
                 },
                 {
+                    "label": "2",
                     "derivative_interpretation": "gross_predicted",
                     "trace_interpretation": "NATURAL_GAS_CONSUMPTION_SUPPLIED",
                     "unit": "therm",
@@ -138,6 +143,7 @@ def aggregation_input_mixed_trace_interpretation():
             "type": "DERIVATIVE_PAIRS",
             "derivative_pairs": [
                 {
+                    "label": "1",
                     "derivative_interpretation": "annualized_weather_normal",
                     "trace_interpretation": "NATURAL_GAS_CONSUMPTION_SUPPLIED",
                     "unit": "therm",
@@ -151,6 +157,7 @@ def aggregation_input_mixed_trace_interpretation():
                     "reporting_n": 5,
                 },
                 {
+                    "label": "2",
                     "derivative_interpretation": "annualized_weather_normal",
                     "trace_interpretation": "ELECTRICITY_CONSUMPTION_SUPPLIED",
                     "unit": "therm",
@@ -179,6 +186,7 @@ def aggregation_input_mixed_unit():
             "type": "DERIVATIVE_PAIRS",
             "derivative_pairs": [
                 {
+                    "label": "1",
                     "derivative_interpretation": "annualized_weather_normal",
                     "trace_interpretation": "NATURAL_GAS_CONSUMPTION_SUPPLIED",
                     "unit": "therm",
@@ -192,6 +200,7 @@ def aggregation_input_mixed_unit():
                     "reporting_n": 5,
                 },
                 {
+                    "label": "2",
                     "derivative_interpretation": "annualized_weather_normal",
                     "trace_interpretation": "NATURAL_GAS_CONSUMPTION_SUPPLIED",
                     "unit": "kWh",
@@ -220,6 +229,7 @@ def aggregation_input_one_invalid():
             "type": "DERIVATIVE_PAIRS",
             "derivative_pairs": [
                 {
+                    "label": "1",
                     "derivative_interpretation": "annualized_weather_normal",
                     "trace_interpretation": "NATURAL_GAS_CONSUMPTION_SUPPLIED",
                     "unit": "therm",
@@ -233,6 +243,7 @@ def aggregation_input_one_invalid():
                     "reporting_n": 5,
                 },
                 {
+                    "label": "2",
                     "derivative_interpretation": "annualized_weather_normal",
                     "trace_interpretation": "NATURAL_GAS_CONSUMPTION_SUPPLIED",
                     "unit": "therm",
@@ -268,6 +279,7 @@ def aggregation_input_one_invalid_default_baseline():
             "type": "DERIVATIVE_PAIRS",
             "derivative_pairs": [
                 {
+                    "label": "1",
                     "derivative_interpretation": "annualized_weather_normal",
                     "trace_interpretation": "NATURAL_GAS_CONSUMPTION_SUPPLIED",
                     "unit": "therm",
@@ -281,6 +293,7 @@ def aggregation_input_one_invalid_default_baseline():
                     "reporting_n": 5,
                 },
                 {
+                    "label": "2",
                     "derivative_interpretation": "annualized_weather_normal",
                     "trace_interpretation": "NATURAL_GAS_CONSUMPTION_SUPPLIED",
                     "unit": "therm",
@@ -316,6 +329,7 @@ def aggregation_input_one_invalid_default_reporting():
             "type": "DERIVATIVE_PAIRS",
             "derivative_pairs": [
                 {
+                    "label": "1",
                     "derivative_interpretation": "annualized_weather_normal",
                     "trace_interpretation": "NATURAL_GAS_CONSUMPTION_SUPPLIED",
                     "unit": "therm",
@@ -329,6 +343,7 @@ def aggregation_input_one_invalid_default_reporting():
                     "reporting_n": 5,
                 },
                 {
+                    "label": "2",
                     "derivative_interpretation": "annualized_weather_normal",
                     "trace_interpretation": "NATURAL_GAS_CONSUMPTION_SUPPLIED",
                     "unit": "therm",
@@ -349,105 +364,114 @@ def aggregation_input_one_invalid_default_reporting():
 def test_basic_usage(aggregation_input):
 
     aggregator = Aggregator()
-    derivative_pair, n_valid, n_invalid = \
-        aggregator.aggregate(aggregation_input)
 
-    assert n_valid == 2
-    assert n_invalid == 0
+    output = aggregator.aggregate(aggregation_input)
 
-    assert derivative_pair.derivative_interpretation == \
+    status = output['status']
+    assert status['1']['baseline_status'] == "ACCEPTED"
+    assert status['1']['reporting_status'] == "ACCEPTED"
+    assert status['2']['baseline_status'] == "ACCEPTED"
+    assert status['2']['reporting_status'] == "ACCEPTED"
+
+    derivative_pair = output["aggregated"]
+
+    assert derivative_pair["label"] is None
+
+    assert derivative_pair["derivative_interpretation"] == \
         "annualized_weather_normal"
 
-    assert derivative_pair.trace_interpretation == \
+    assert derivative_pair["trace_interpretation"] == \
         "NATURAL_GAS_CONSUMPTION_SUPPLIED"
 
-    baseline = derivative_pair.baseline
-    assert baseline.label is None
-    assert baseline.value == 20
-    assert baseline.lower == 5
-    assert baseline.upper == 5
-    assert baseline.n == 10
+    baseline = derivative_pair["baseline"]
+    assert baseline["value"] == 20
+    assert baseline["lower"] == 5
+    assert baseline["upper"] == 5
+    assert baseline["n"] == 10
 
-    reporting = derivative_pair.reporting
-    assert reporting.label is None
-    assert reporting.value == 20
-    assert reporting.lower == 10
-    assert reporting.upper == 10
-    assert reporting.n == 10
+    reporting = derivative_pair["reporting"]
+    assert reporting["value"] == 20
+    assert reporting["lower"] == 10
+    assert reporting["upper"] == 10
+    assert reporting["n"] == 10
 
 
 def test_empty(aggregation_input_empty):
+
     aggregator = Aggregator()
     with pytest.raises(ValueError):
         aggregator.aggregate(aggregation_input_empty)
 
 
 def test_single(aggregation_input_single):
+
     aggregator = Aggregator()
+    output = aggregator.aggregate(aggregation_input_single)
 
-    derivative_pairs, n_valid, n_invalid = \
-        aggregator.aggregate(aggregation_input_single)
-
-    assert n_valid == 1
-    assert n_invalid == 0
+    status = output['status']
+    assert status['1']['baseline_status'] == "ACCEPTED"
+    assert status['1']['reporting_status'] == "ACCEPTED"
 
 
 def test_mixed_derivative_interpretaiton_fails(
         aggregation_input_mixed_derivative_interpretation):
 
     aggregator = Aggregator()
-
     with pytest.raises(ValueError):
-        derivative_pair, n_valid, n_invalid = \
-            aggregator.aggregate(aggregation_input_mixed_derivative_interpretation)
+        aggregator.aggregate(aggregation_input_mixed_derivative_interpretation)
 
 
 def test_mixed_trace_interpretaiton_fails(
         aggregation_input_mixed_trace_interpretation):
 
     aggregator = Aggregator()
-
     with pytest.raises(ValueError):
-        derivative_pair, n_valid, n_invalid = \
-            aggregator.aggregate(aggregation_input_mixed_trace_interpretation)
+        aggregator.aggregate(aggregation_input_mixed_trace_interpretation)
 
 
 def test_mixed_unit_fails(aggregation_input_mixed_unit):
 
     aggregator = Aggregator()
-
     with pytest.raises(ValueError):
-        derivative_pair, n_valid, n_invalid = \
-            aggregator.aggregate(aggregation_input_mixed_unit)
+        aggregator.aggregate(aggregation_input_mixed_unit)
 
 
 def test_missing(aggregation_input_one_invalid):
 
     aggregator = Aggregator()
+    output = aggregator.aggregate(aggregation_input_one_invalid)
 
-    derivative_pair, n_valid, n_invalid = \
-        aggregator.aggregate(aggregation_input_one_invalid)
+    status = output['status']
+    assert status['1']['baseline_status'] == "REJECTED"
+    assert status['1']['reporting_status'] == "ACCEPTED"
+    assert status['2']['baseline_status'] == "ACCEPTED"
+    assert status['2']['reporting_status'] == "ACCEPTED"
 
-    assert n_valid == 1
-    assert n_invalid == 1
 
-
-def test_missing_with_baseline_default(aggregation_input_one_invalid_default_baseline):
-
-    aggregator = Aggregator()
-
-    derivative_pair, n_valid, n_invalid = \
-        aggregator.aggregate(aggregation_input_one_invalid_default_baseline)
-
-    assert n_valid == 2
-    assert n_invalid == 0
-
-def test_missing_with_reporting_default(aggregation_input_one_invalid_default_reporting):
+def test_missing_with_baseline_default(
+        aggregation_input_one_invalid_default_baseline):
 
     aggregator = Aggregator()
+    output = aggregator.aggregate(
+        aggregation_input_one_invalid_default_baseline)
 
-    derivative_pair, n_valid, n_invalid = \
-        aggregator.aggregate(aggregation_input_one_invalid_default_reporting)
+    status = output['status']
+    assert status['1']['baseline_status'] == "DEFAULT"
+    assert status['1']['reporting_status'] == "ACCEPTED"
+    assert status['2']['baseline_status'] == "ACCEPTED"
+    assert status['2']['reporting_status'] == "ACCEPTED"
 
-    assert n_valid == 2
-    assert n_invalid == 0
+
+def test_missing_with_reporting_default(
+        aggregation_input_one_invalid_default_reporting):
+
+    aggregator = Aggregator()
+    output = aggregator.aggregate(
+        aggregation_input_one_invalid_default_reporting)
+
+    status = output['status']
+    assert status['1']['baseline_status'] == "ACCEPTED"
+    assert status['1']['reporting_status'] == "ACCEPTED"
+    assert status['2']['baseline_status'] == "ACCEPTED"
+    assert status['2']['reporting_status'] == "DEFAULT"
+

--- a/tests/ee/test_aggregator.py
+++ b/tests/ee/test_aggregator.py
@@ -51,19 +51,9 @@ def derivative_pairs_one_empty():
     ]
 
 
-def sum_func(d1, d2):
-    return Derivative(
-        None,
-        d1.value + d2.value,
-        (d1.lower**2 + d2.lower**2)**0.5,
-        (d1.upper**2 + d2.upper**2)**0.5,
-        d1.n + d2.n,
-    )
-
-
 def test_basic_usage(derivative_pairs):
 
-    aggregator = Aggregator(sum_func)
+    aggregator = Aggregator("SUM")
     derivative_pair, n_valid, n_invalid = \
         aggregator.aggregate(derivative_pairs, "interpretation")
 
@@ -89,7 +79,7 @@ def test_basic_usage(derivative_pairs):
 
 def test_mixed_interpretaiton_fails(derivative_pairs_mixed_interpretation):
 
-    aggregator = Aggregator(sum_func)
+    aggregator = Aggregator()
 
     with pytest.raises(ValueError):
         derivative_pair, n_valid, n_invalid = \
@@ -99,7 +89,7 @@ def test_mixed_interpretaiton_fails(derivative_pairs_mixed_interpretation):
 
 def test_missing(derivative_pairs_one_empty):
 
-    aggregator = Aggregator(sum_func)
+    aggregator = Aggregator()
 
     derivative_pair, n_valid, n_invalid = \
         aggregator.aggregate(derivative_pairs_one_empty,
@@ -111,7 +101,7 @@ def test_missing(derivative_pairs_one_empty):
 
 def test_missing_with_default(derivative_pairs_one_empty):
 
-    aggregator = Aggregator(sum_func, baseline_default_value=Derivative(
+    aggregator = Aggregator(baseline_default_value=Derivative(
         None, 0, 0, 0, 0
     ))
 

--- a/tests/ee/test_aggregator.py
+++ b/tests/ee/test_aggregator.py
@@ -4,103 +4,362 @@ from eemeter.ee.aggregate import Aggregator
 
 
 @pytest.fixture
-def derivative_pairs_empty():
-    return []
+def aggregation_input():
+    return {
+        "type": "BASIC_AGGREGATION",
+        "aggregation_interpretation": "SUM",
+        "trace_interpretation": "NATURAL_GAS_CONSUMPTION_SUPPLIED",
+        "derivative_interpretation": "annualized_weather_normal",
+        "derivatives": {
+            "type": "DERIVATIVE_PAIRS",
+            "derivative_pairs": [
+                {
+                    "derivative_interpretation": "annualized_weather_normal",
+                    "trace_interpretation": "NATURAL_GAS_CONSUMPTION_SUPPLIED",
+                    "unit": "therm",
+                    "baseline_value": 10,
+                    "baseline_lower": 3,
+                    "baseline_upper": 3,
+                    "baseline_n": 5,
+                    "reporting_value": 10,
+                    "reporting_lower": 6,
+                    "reporting_upper": 6,
+                    "reporting_n": 5,
+                },
+                {
+                    "derivative_interpretation": "annualized_weather_normal",
+                    "trace_interpretation": "NATURAL_GAS_CONSUMPTION_SUPPLIED",
+                    "unit": "therm",
+                    "baseline_value": 10,
+                    "baseline_lower": 4,
+                    "baseline_upper": 4,
+                    "baseline_n": 5,
+                    "reporting_value": 10,
+                    "reporting_lower": 8,
+                    "reporting_upper": 8,
+                    "reporting_n": 5,
+                }
+            ]
+        }
+    }
 
 
 @pytest.fixture
-def derivative_pairs_single():
-    return [
-        DerivativePair(
-            "interpretation",
-            "kWh",
-            Derivative("1", 10, 3, 3, 5, None),
-            Derivative("2", 10, 6, 6, 5, None),
-        ),
-    ]
+def aggregation_input_empty():
+    return {
+        "type": "BASIC_AGGREGATION",
+        "aggregation_interpretation": "SUM",
+        "trace_interpretation": "NATURAL_GAS_CONSUMPTION_SUPPLIED",
+        "derivative_interpretation": "annualized_weather_normal",
+        "derivatives": {
+            "type": "DERIVATIVE_PAIRS",
+            "derivative_pairs": []
+        }
+    }
 
 
 @pytest.fixture
-def derivative_pairs():
-    return [
-        DerivativePair(
-            "interpretation",
-            "kWh",
-            Derivative("1", 10, 3, 3, 5, None),
-            Derivative("2", 10, 6, 6, 5, None),
-        ),
-        DerivativePair(
-            "interpretation",
-            "kWh",
-            Derivative("1", 10, 4, 4, 5, None),
-            Derivative("2", 10, 8, 8, 5, None),
-        ),
-    ]
+def aggregation_input_single():
+    return {
+        "type": "BASIC_AGGREGATION",
+        "aggregation_interpretation": "SUM",
+        "trace_interpretation": "NATURAL_GAS_CONSUMPTION_SUPPLIED",
+        "derivative_interpretation": "annualized_weather_normal",
+        "derivatives": {
+            "type": "DERIVATIVE_PAIRS",
+            "derivative_pairs": [
+                {
+                    "derivative_interpretation": "annualized_weather_normal",
+                    "trace_interpretation": "NATURAL_GAS_CONSUMPTION_SUPPLIED",
+                    "unit": "therm",
+                    "baseline_value": 10,
+                    "baseline_lower": 3,
+                    "baseline_upper": 3,
+                    "baseline_n": 5,
+                    "reporting_value": 10,
+                    "reporting_lower": 6,
+                    "reporting_upper": 6,
+                    "reporting_n": 5,
+                }
+            ]
+        }
+    }
 
 
 @pytest.fixture
-def derivative_pairs_mixed_interpretation():
-    return [
-        DerivativePair(
-            "interpretation1",
-            "kWh",
-            Derivative("1", 10, 3, 3, 5, None),
-            Derivative("2", 10, 6, 6, 5, None),
-        ),
-        DerivativePair(
-            "interpretation2",
-            "kWh",
-            Derivative("1", 10, 4, 4, 5, None),
-            Derivative("2", 10, 8, 8, 5, None),
-        ),
-    ]
+def aggregation_input_mixed_derivative_interpretation():
+    return {
+        "type": "BASIC_AGGREGATION",
+        "aggregation_interpretation": "SUM",
+        "trace_interpretation": "NATURAL_GAS_CONSUMPTION_SUPPLIED",
+        "derivative_interpretation": "annualized_weather_normal",
+        "derivatives": {
+            "type": "DERIVATIVE_PAIRS",
+            "derivative_pairs": [
+                {
+                    "derivative_interpretation": "annualized_weather_normal",
+                    "trace_interpretation": "NATURAL_GAS_CONSUMPTION_SUPPLIED",
+                    "unit": "therm",
+                    "baseline_value": 10,
+                    "baseline_lower": 3,
+                    "baseline_upper": 3,
+                    "baseline_n": 5,
+                    "reporting_value": 10,
+                    "reporting_lower": 6,
+                    "reporting_upper": 6,
+                    "reporting_n": 5,
+                },
+                {
+                    "derivative_interpretation": "gross_predicted",
+                    "trace_interpretation": "NATURAL_GAS_CONSUMPTION_SUPPLIED",
+                    "unit": "therm",
+                    "baseline_value": 10,
+                    "baseline_lower": 4,
+                    "baseline_upper": 4,
+                    "baseline_n": 5,
+                    "reporting_value": 10,
+                    "reporting_lower": 8,
+                    "reporting_upper": 8,
+                    "reporting_n": 5,
+                }
+            ]
+        }
+    }
+
 
 @pytest.fixture
-def derivative_pairs_mixed_unit():
-    return [
-        DerivativePair(
-            "interpretation1",
-            "kWh",
-            Derivative("1", 10, 3, 3, 5, None),
-            Derivative("2", 10, 6, 6, 5, None),
-        ),
-        DerivativePair(
-            "interpretation2",
-            "therm",
-            Derivative("1", 10, 4, 4, 5, None),
-            Derivative("2", 10, 8, 8, 5, None),
-        ),
-    ]
+def aggregation_input_mixed_trace_interpretation():
+    return {
+        "type": "BASIC_AGGREGATION",
+        "aggregation_interpretation": "SUM",
+        "trace_interpretation": "NATURAL_GAS_CONSUMPTION_SUPPLIED",
+        "derivative_interpretation": "annualized_weather_normal",
+        "derivatives": {
+            "type": "DERIVATIVE_PAIRS",
+            "derivative_pairs": [
+                {
+                    "derivative_interpretation": "annualized_weather_normal",
+                    "trace_interpretation": "NATURAL_GAS_CONSUMPTION_SUPPLIED",
+                    "unit": "therm",
+                    "baseline_value": 10,
+                    "baseline_lower": 3,
+                    "baseline_upper": 3,
+                    "baseline_n": 5,
+                    "reporting_value": 10,
+                    "reporting_lower": 6,
+                    "reporting_upper": 6,
+                    "reporting_n": 5,
+                },
+                {
+                    "derivative_interpretation": "annualized_weather_normal",
+                    "trace_interpretation": "ELECTRICITY_CONSUMPTION_SUPPLIED",
+                    "unit": "therm",
+                    "baseline_value": 10,
+                    "baseline_lower": 4,
+                    "baseline_upper": 4,
+                    "baseline_n": 5,
+                    "reporting_value": 10,
+                    "reporting_lower": 8,
+                    "reporting_upper": 8,
+                    "reporting_n": 5,
+                }
+            ]
+        }
+    }
 
 
 @pytest.fixture
-def derivative_pairs_one_invalid():
-    return [
-        DerivativePair(
-            "interpretation",
-            "kWh",
-            Derivative("1", None, None, None, None, None),
-            Derivative("2", 10, 3, 3, 5, None),
-        ),
-        DerivativePair(
-            "interpretation",
-            "kWh",
-            Derivative("1", 10, 4, 4, 5, None),
-            Derivative("2", 10, 8, 8, 5, None),
-        ),
-    ]
+def aggregation_input_mixed_unit():
+    return {
+        "type": "BASIC_AGGREGATION",
+        "aggregation_interpretation": "SUM",
+        "trace_interpretation": "NATURAL_GAS_CONSUMPTION_SUPPLIED",
+        "derivative_interpretation": "annualized_weather_normal",
+        "derivatives": {
+            "type": "DERIVATIVE_PAIRS",
+            "derivative_pairs": [
+                {
+                    "derivative_interpretation": "annualized_weather_normal",
+                    "trace_interpretation": "NATURAL_GAS_CONSUMPTION_SUPPLIED",
+                    "unit": "therm",
+                    "baseline_value": 10,
+                    "baseline_lower": 3,
+                    "baseline_upper": 3,
+                    "baseline_n": 5,
+                    "reporting_value": 10,
+                    "reporting_lower": 6,
+                    "reporting_upper": 6,
+                    "reporting_n": 5,
+                },
+                {
+                    "derivative_interpretation": "annualized_weather_normal",
+                    "trace_interpretation": "NATURAL_GAS_CONSUMPTION_SUPPLIED",
+                    "unit": "kWh",
+                    "baseline_value": 10,
+                    "baseline_lower": 4,
+                    "baseline_upper": 4,
+                    "baseline_n": 5,
+                    "reporting_value": 10,
+                    "reporting_lower": 8,
+                    "reporting_upper": 8,
+                    "reporting_n": 5,
+                }
+            ]
+        }
+    }
 
 
-def test_basic_usage(derivative_pairs):
+@pytest.fixture
+def aggregation_input_one_invalid():
+    return {
+        "type": "BASIC_AGGREGATION",
+        "aggregation_interpretation": "SUM",
+        "trace_interpretation": "NATURAL_GAS_CONSUMPTION_SUPPLIED",
+        "derivative_interpretation": "annualized_weather_normal",
+        "derivatives": {
+            "type": "DERIVATIVE_PAIRS",
+            "derivative_pairs": [
+                {
+                    "derivative_interpretation": "annualized_weather_normal",
+                    "trace_interpretation": "NATURAL_GAS_CONSUMPTION_SUPPLIED",
+                    "unit": "therm",
+                    "baseline_value": None,
+                    "baseline_lower": None,
+                    "baseline_upper": None,
+                    "baseline_n": None,
+                    "reporting_value": 10,
+                    "reporting_lower": 6,
+                    "reporting_upper": 6,
+                    "reporting_n": 5,
+                },
+                {
+                    "derivative_interpretation": "annualized_weather_normal",
+                    "trace_interpretation": "NATURAL_GAS_CONSUMPTION_SUPPLIED",
+                    "unit": "therm",
+                    "baseline_value": 10,
+                    "baseline_lower": 4,
+                    "baseline_upper": 4,
+                    "baseline_n": 5,
+                    "reporting_value": 10,
+                    "reporting_lower": 8,
+                    "reporting_upper": 8,
+                    "reporting_n": 5,
+                }
+            ]
+        }
+    }
 
-    aggregator = Aggregator("SUM")
+
+@pytest.fixture
+def aggregation_input_one_invalid_default_baseline():
+    return {
+        "type": "BASIC_AGGREGATION",
+        "aggregation_interpretation": "SUM",
+        "trace_interpretation": "NATURAL_GAS_CONSUMPTION_SUPPLIED",
+        "derivative_interpretation": "annualized_weather_normal",
+        "baseline_default_value": {
+            "type": "SIMPLE_DEFAULT",
+            "value": 0,
+            "lower": 0,
+            "upper": 0,
+            "n": 0,
+        },
+        "derivatives": {
+            "type": "DERIVATIVE_PAIRS",
+            "derivative_pairs": [
+                {
+                    "derivative_interpretation": "annualized_weather_normal",
+                    "trace_interpretation": "NATURAL_GAS_CONSUMPTION_SUPPLIED",
+                    "unit": "therm",
+                    "baseline_value": None,
+                    "baseline_lower": None,
+                    "baseline_upper": None,
+                    "baseline_n": None,
+                    "reporting_value": 10,
+                    "reporting_lower": 6,
+                    "reporting_upper": 6,
+                    "reporting_n": 5,
+                },
+                {
+                    "derivative_interpretation": "annualized_weather_normal",
+                    "trace_interpretation": "NATURAL_GAS_CONSUMPTION_SUPPLIED",
+                    "unit": "therm",
+                    "baseline_value": 10,
+                    "baseline_lower": 4,
+                    "baseline_upper": 4,
+                    "baseline_n": 5,
+                    "reporting_value": 10,
+                    "reporting_lower": 8,
+                    "reporting_upper": 8,
+                    "reporting_n": 5,
+                }
+            ]
+        }
+    }
+
+
+@pytest.fixture
+def aggregation_input_one_invalid_default_reporting():
+    return {
+        "type": "BASIC_AGGREGATION",
+        "aggregation_interpretation": "SUM",
+        "trace_interpretation": "NATURAL_GAS_CONSUMPTION_SUPPLIED",
+        "derivative_interpretation": "annualized_weather_normal",
+        "reporting_default_value": {
+            "type": "SIMPLE_DEFAULT",
+            "value": 0,
+            "lower": 0,
+            "upper": 0,
+            "n": 0,
+        },
+        "derivatives": {
+            "type": "DERIVATIVE_PAIRS",
+            "derivative_pairs": [
+                {
+                    "derivative_interpretation": "annualized_weather_normal",
+                    "trace_interpretation": "NATURAL_GAS_CONSUMPTION_SUPPLIED",
+                    "unit": "therm",
+                    "baseline_value": 10,
+                    "baseline_lower": 3,
+                    "baseline_upper": 3,
+                    "baseline_n": 5,
+                    "reporting_value": 10,
+                    "reporting_lower": 6,
+                    "reporting_upper": 6,
+                    "reporting_n": 5,
+                },
+                {
+                    "derivative_interpretation": "annualized_weather_normal",
+                    "trace_interpretation": "NATURAL_GAS_CONSUMPTION_SUPPLIED",
+                    "unit": "therm",
+                    "baseline_value": 10,
+                    "baseline_lower": 4,
+                    "baseline_upper": 4,
+                    "baseline_n": 5,
+                    "reporting_value": None,
+                    "reporting_lower": None,
+                    "reporting_upper": None,
+                    "reporting_n": None,
+                }
+            ]
+        }
+    }
+
+
+def test_basic_usage(aggregation_input):
+
+    aggregator = Aggregator()
     derivative_pair, n_valid, n_invalid = \
-        aggregator.aggregate(derivative_pairs, "interpretation")
+        aggregator.aggregate(aggregation_input)
 
     assert n_valid == 2
     assert n_invalid == 0
 
-    assert derivative_pair.interpretation == "interpretation"
+    assert derivative_pair.derivative_interpretation == \
+        "annualized_weather_normal"
+
+    assert derivative_pair.trace_interpretation == \
+        "NATURAL_GAS_CONSUMPTION_SUPPLIED"
 
     baseline = derivative_pair.baseline
     assert baseline.label is None
@@ -116,63 +375,79 @@ def test_basic_usage(derivative_pairs):
     assert reporting.upper == 10
     assert reporting.n == 10
 
-def test_empty(derivative_pairs_empty):
+
+def test_empty(aggregation_input_empty):
     aggregator = Aggregator()
     with pytest.raises(ValueError):
-        aggregator.aggregate(derivative_pairs_empty)
+        aggregator.aggregate(aggregation_input_empty)
 
 
-def test_single(derivative_pairs_single):
+def test_single(aggregation_input_single):
     aggregator = Aggregator()
 
     derivative_pairs, n_valid, n_invalid = \
-        aggregator.aggregate(derivative_pairs_single)
+        aggregator.aggregate(aggregation_input_single)
 
     assert n_valid == 1
     assert n_invalid == 0
 
 
-def test_mixed_interpretaiton_fails(derivative_pairs_mixed_interpretation):
+def test_mixed_derivative_interpretaiton_fails(
+        aggregation_input_mixed_derivative_interpretation):
 
     aggregator = Aggregator()
 
     with pytest.raises(ValueError):
         derivative_pair, n_valid, n_invalid = \
-            aggregator.aggregate(derivative_pairs_mixed_interpretation,
-                                 "interpretation1")
+            aggregator.aggregate(aggregation_input_mixed_derivative_interpretation)
 
 
-def test_mixed_unit_fails(derivative_pairs_mixed_unit):
+def test_mixed_trace_interpretaiton_fails(
+        aggregation_input_mixed_trace_interpretation):
 
     aggregator = Aggregator()
 
     with pytest.raises(ValueError):
         derivative_pair, n_valid, n_invalid = \
-            aggregator.aggregate(derivative_pairs_mixed_unit,
-                                 "kWh")
+            aggregator.aggregate(aggregation_input_mixed_trace_interpretation)
 
 
-def test_missing(derivative_pairs_one_invalid):
+def test_mixed_unit_fails(aggregation_input_mixed_unit):
+
+    aggregator = Aggregator()
+
+    with pytest.raises(ValueError):
+        derivative_pair, n_valid, n_invalid = \
+            aggregator.aggregate(aggregation_input_mixed_unit)
+
+
+def test_missing(aggregation_input_one_invalid):
 
     aggregator = Aggregator()
 
     derivative_pair, n_valid, n_invalid = \
-        aggregator.aggregate(derivative_pairs_one_invalid,
-                             "interpretation")
+        aggregator.aggregate(aggregation_input_one_invalid)
 
     assert n_valid == 1
     assert n_invalid == 1
 
 
-def test_missing_with_default(derivative_pairs_one_invalid):
+def test_missing_with_baseline_default(aggregation_input_one_invalid_default_baseline):
 
-    aggregator = Aggregator(baseline_default_value=Derivative(
-        None, 0, 0, 0, 0, None
-    ))
+    aggregator = Aggregator()
 
     derivative_pair, n_valid, n_invalid = \
-        aggregator.aggregate(derivative_pairs_one_invalid,
-                             "interpretation")
+        aggregator.aggregate(aggregation_input_one_invalid_default_baseline)
+
+    assert n_valid == 2
+    assert n_invalid == 0
+
+def test_missing_with_reporting_default(aggregation_input_one_invalid_default_reporting):
+
+    aggregator = Aggregator()
+
+    derivative_pair, n_valid, n_invalid = \
+        aggregator.aggregate(aggregation_input_one_invalid_default_reporting)
 
     assert n_valid == 2
     assert n_invalid == 0

--- a/tests/ee/test_aggregator.py
+++ b/tests/ee/test_aggregator.py
@@ -368,8 +368,10 @@ def test_basic_usage(aggregation_input):
     output = aggregator.aggregate(aggregation_input)
 
     status = output['status']
+    assert status['1']['status'] == "ACCEPTED"
     assert status['1']['baseline_status'] == "ACCEPTED"
     assert status['1']['reporting_status'] == "ACCEPTED"
+    assert status['2']['status'] == "ACCEPTED"
     assert status['2']['baseline_status'] == "ACCEPTED"
     assert status['2']['reporting_status'] == "ACCEPTED"
 
@@ -442,8 +444,10 @@ def test_missing(aggregation_input_one_invalid):
     output = aggregator.aggregate(aggregation_input_one_invalid)
 
     status = output['status']
+    assert status['1']['status'] == "REJECTED"
     assert status['1']['baseline_status'] == "REJECTED"
     assert status['1']['reporting_status'] == "ACCEPTED"
+    assert status['2']['status'] == "ACCEPTED"
     assert status['2']['baseline_status'] == "ACCEPTED"
     assert status['2']['reporting_status'] == "ACCEPTED"
 

--- a/tests/ee/test_aggregator.py
+++ b/tests/ee/test_aggregator.py
@@ -8,13 +8,13 @@ def derivative_pairs():
     return [
         DerivativePair(
             "interpretation",
-            Derivative("1", 10, 3, 3, 5),
-            Derivative("2", 10, 6, 6, 5),
+            Derivative("1", 10, 3, 3, 5, None),
+            Derivative("2", 10, 6, 6, 5, None),
         ),
         DerivativePair(
             "interpretation",
-            Derivative("1", 10, 4, 4, 5),
-            Derivative("2", 10, 8, 8, 5),
+            Derivative("1", 10, 4, 4, 5, None),
+            Derivative("2", 10, 8, 8, 5, None),
         ),
     ]
 
@@ -24,13 +24,13 @@ def derivative_pairs_mixed_interpretation():
     return [
         DerivativePair(
             "interpretation1",
-            Derivative("1", 10, 3, 3, 5),
-            Derivative("2", 10, 6, 6, 5),
+            Derivative("1", 10, 3, 3, 5, None),
+            Derivative("2", 10, 6, 6, 5, None),
         ),
         DerivativePair(
             "interpretation2",
-            Derivative("1", 10, 4, 4, 5),
-            Derivative("2", 10, 8, 8, 5),
+            Derivative("1", 10, 4, 4, 5, None),
+            Derivative("2", 10, 8, 8, 5, None),
         ),
     ]
 
@@ -41,12 +41,12 @@ def derivative_pairs_one_empty():
         DerivativePair(
             "interpretation",
             None,
-            Derivative("2", 10, 3, 3, 5),
+            Derivative("2", 10, 3, 3, 5, None),
         ),
         DerivativePair(
             "interpretation",
-            Derivative("1", 10, 4, 4, 5),
-            Derivative("2", 10, 8, 8, 5),
+            Derivative("1", 10, 4, 4, 5, None),
+            Derivative("2", 10, 8, 8, 5, None),
         ),
     ]
 
@@ -102,7 +102,7 @@ def test_missing(derivative_pairs_one_empty):
 def test_missing_with_default(derivative_pairs_one_empty):
 
     aggregator = Aggregator(baseline_default_value=Derivative(
-        None, 0, 0, 0, 0
+        None, 0, 0, 0, 0, None
     ))
 
     derivative_pair, n_valid, n_invalid = \

--- a/tests/ee/test_aggregator.py
+++ b/tests/ee/test_aggregator.py
@@ -4,15 +4,34 @@ from eemeter.ee.aggregate import Aggregator
 
 
 @pytest.fixture
+def derivative_pairs_empty():
+    return []
+
+
+@pytest.fixture
+def derivative_pairs_single():
+    return [
+        DerivativePair(
+            "interpretation",
+            "kWh",
+            Derivative("1", 10, 3, 3, 5, None),
+            Derivative("2", 10, 6, 6, 5, None),
+        ),
+    ]
+
+
+@pytest.fixture
 def derivative_pairs():
     return [
         DerivativePair(
             "interpretation",
+            "kWh",
             Derivative("1", 10, 3, 3, 5, None),
             Derivative("2", 10, 6, 6, 5, None),
         ),
         DerivativePair(
             "interpretation",
+            "kWh",
             Derivative("1", 10, 4, 4, 5, None),
             Derivative("2", 10, 8, 8, 5, None),
         ),
@@ -24,11 +43,30 @@ def derivative_pairs_mixed_interpretation():
     return [
         DerivativePair(
             "interpretation1",
+            "kWh",
             Derivative("1", 10, 3, 3, 5, None),
             Derivative("2", 10, 6, 6, 5, None),
         ),
         DerivativePair(
             "interpretation2",
+            "kWh",
+            Derivative("1", 10, 4, 4, 5, None),
+            Derivative("2", 10, 8, 8, 5, None),
+        ),
+    ]
+
+@pytest.fixture
+def derivative_pairs_mixed_unit():
+    return [
+        DerivativePair(
+            "interpretation1",
+            "kWh",
+            Derivative("1", 10, 3, 3, 5, None),
+            Derivative("2", 10, 6, 6, 5, None),
+        ),
+        DerivativePair(
+            "interpretation2",
+            "therm",
             Derivative("1", 10, 4, 4, 5, None),
             Derivative("2", 10, 8, 8, 5, None),
         ),
@@ -40,11 +78,13 @@ def derivative_pairs_one_empty():
     return [
         DerivativePair(
             "interpretation",
+            "kWh",
             None,
             Derivative("2", 10, 3, 3, 5, None),
         ),
         DerivativePair(
             "interpretation",
+            "kWh",
             Derivative("1", 10, 4, 4, 5, None),
             Derivative("2", 10, 8, 8, 5, None),
         ),
@@ -76,6 +116,21 @@ def test_basic_usage(derivative_pairs):
     assert reporting.upper == 10
     assert reporting.n == 10
 
+def test_empty(derivative_pairs_empty):
+    aggregator = Aggregator()
+    with pytest.raises(ValueError):
+        aggregator.aggregate(derivative_pairs_empty)
+
+
+def test_single(derivative_pairs_single):
+    aggregator = Aggregator()
+
+    derivative_pairs, n_valid, n_invalid = \
+        aggregator.aggregate(derivative_pairs_single)
+
+    assert n_valid == 1
+    assert n_invalid == 0
+
 
 def test_mixed_interpretaiton_fails(derivative_pairs_mixed_interpretation):
 
@@ -85,6 +140,16 @@ def test_mixed_interpretaiton_fails(derivative_pairs_mixed_interpretation):
         derivative_pair, n_valid, n_invalid = \
             aggregator.aggregate(derivative_pairs_mixed_interpretation,
                                  "interpretation1")
+
+
+def test_mixed_unit_fails(derivative_pairs_mixed_unit):
+
+    aggregator = Aggregator()
+
+    with pytest.raises(ValueError):
+        derivative_pair, n_valid, n_invalid = \
+            aggregator.aggregate(derivative_pairs_mixed_unit,
+                                 "kWh")
 
 
 def test_missing(derivative_pairs_one_empty):

--- a/tests/ee/test_aggregator.py
+++ b/tests/ee/test_aggregator.py
@@ -74,12 +74,12 @@ def derivative_pairs_mixed_unit():
 
 
 @pytest.fixture
-def derivative_pairs_one_empty():
+def derivative_pairs_one_invalid():
     return [
         DerivativePair(
             "interpretation",
             "kWh",
-            None,
+            Derivative("1", None, None, None, None, None),
             Derivative("2", 10, 3, 3, 5, None),
         ),
         DerivativePair(
@@ -152,26 +152,26 @@ def test_mixed_unit_fails(derivative_pairs_mixed_unit):
                                  "kWh")
 
 
-def test_missing(derivative_pairs_one_empty):
+def test_missing(derivative_pairs_one_invalid):
 
     aggregator = Aggregator()
 
     derivative_pair, n_valid, n_invalid = \
-        aggregator.aggregate(derivative_pairs_one_empty,
+        aggregator.aggregate(derivative_pairs_one_invalid,
                              "interpretation")
 
     assert n_valid == 1
     assert n_invalid == 1
 
 
-def test_missing_with_default(derivative_pairs_one_empty):
+def test_missing_with_default(derivative_pairs_one_invalid):
 
     aggregator = Aggregator(baseline_default_value=Derivative(
         None, 0, 0, 0, 0, None
     ))
 
     derivative_pair, n_valid, n_invalid = \
-        aggregator.aggregate(derivative_pairs_one_empty,
+        aggregator.aggregate(derivative_pairs_one_invalid,
                              "interpretation")
 
     assert n_valid == 2

--- a/tests/ee/test_aggregator.py
+++ b/tests/ee/test_aggregator.py
@@ -1,0 +1,53 @@
+import pytest
+from eemeter.ee.meter import DerivativePair, Derivative, Aggregator
+
+
+@pytest.fixture
+def derivative_pairs():
+    return [
+        DerivativePair(
+            "interpretation",
+            Derivative("1", 10, 3, 3, 5),
+            Derivative("2", 10, 6, 6, 5),
+        ),
+        DerivativePair(
+            "interpretation",
+            Derivative("1", 10, 4, 4, 5),
+            Derivative("2", 10, 8, 8, 5),
+        ),
+    ]
+
+
+def test_basic_usage(derivative_pairs):
+
+    def sum_func(d1, d2):
+        return Derivative(
+            None,
+            d1.value + d2.value,
+            (d1.lower**2 + d2.lower**2)**0.5,
+            (d1.upper**2 + d2.upper**2)**0.5,
+            d1.n + d2.n,
+        )
+
+    aggregator = Aggregator(sum_func)
+    derivative_pair, n_valid, n_invalid = \
+        aggregator.aggregate(derivative_pairs, "interpretation")
+
+    assert n_valid == 2
+    assert n_invalid == 0
+
+    assert derivative_pair.interpretation == "interpretation"
+
+    baseline = derivative_pair.baseline
+    assert baseline.label is None
+    assert baseline.value == 20
+    assert baseline.lower == 5
+    assert baseline.upper == 5
+    assert baseline.n == 10
+
+    reporting = derivative_pair.reporting
+    assert reporting.label is None
+    assert reporting.value == 20
+    assert reporting.lower == 10
+    assert reporting.upper == 10
+    assert reporting.n == 10

--- a/tests/ee/test_annualized_weather_normal.py
+++ b/tests/ee/test_annualized_weather_normal.py
@@ -3,7 +3,10 @@ import tempfile
 import pytest
 from numpy.testing import assert_allclose
 
-from eemeter.modeling.formatters import ModelDataFormatter
+from eemeter.modeling.formatters import (
+    ModelDataFormatter,
+    ModelDataBillingFormatter,
+)
 from eemeter.ee.derivatives import annualized_weather_normal
 from eemeter.testing.mocks import MockModel, MockWeatherClient
 from eemeter.weather import TMY3WeatherSource
@@ -18,7 +21,7 @@ def mock_tmy3_weather_source():
     return ws
 
 
-def test_basic_usage(mock_tmy3_weather_source):
+def test_daily(mock_tmy3_weather_source):
     formatter = ModelDataFormatter("D")
     model = MockModel()
     output = annualized_weather_normal(
@@ -26,3 +29,21 @@ def test_basic_usage(mock_tmy3_weather_source):
 
     assert_allclose(output['annualized_weather_normal'][:4],
                     (365, 19.1049731745428, 19.1049731745428, 365))
+
+    serialized = output['annualized_weather_normal'][4]
+    assert len(serialized) == 365
+    assert serialized['2015-01-01T00:00:00+00:00'] == 32
+
+
+def test_monthly(mock_tmy3_weather_source):
+    formatter = ModelDataBillingFormatter()
+    model = MockModel()
+    output = annualized_weather_normal(
+        formatter, model, mock_tmy3_weather_source)
+
+    assert_allclose(output['annualized_weather_normal'][:4],
+                    (365, 19.1049731745428, 19.1049731745428, 365))
+
+    serialized = output['annualized_weather_normal'][4]
+    assert len(serialized) == 365
+    assert serialized['2015-01-01T00:00:00+00:00'] == 32

--- a/tests/ee/test_annualized_weather_normal.py
+++ b/tests/ee/test_annualized_weather_normal.py
@@ -24,5 +24,5 @@ def test_basic_usage(mock_tmy3_weather_source):
     output = annualized_weather_normal(
         formatter, model, mock_tmy3_weather_source)
 
-    assert_allclose(output['annualized_weather_normal'],
+    assert_allclose(output['annualized_weather_normal'][:4],
                     (365, 19.1049731745428, 19.1049731745428, 365))

--- a/tests/ee/test_energy_efficiency_meter_trace_centric.py
+++ b/tests/ee/test_energy_efficiency_meter_trace_centric.py
@@ -23,10 +23,10 @@ from eemeter.weather import ISDWeatherSource
 def daily_data():
     index = pd.date_range('2012-01-01', periods=365*4, freq='D', tz=pytz.UTC)
     data = {
-        "value": np.tile(1, (365 * 4,)),
-        "estimated": np.tile(False, (365 * 4,))
+        'value': np.tile(1, (365 * 4,)),
+        'estimated': np.tile(False, (365 * 4,))
     }
-    return pd.DataFrame(data, index=index, columns=["value", "estimated"])
+    return pd.DataFrame(data, index=index, columns=['value', 'estimated'])
 
 
 @pytest.fixture
@@ -38,7 +38,7 @@ def energy_trace(daily_data):
 @pytest.fixture
 def mock_isd_weather_source():
     tmp_dir = tempfile.mkdtemp()
-    ws = ISDWeatherSource("722880", tmp_dir)
+    ws = ISDWeatherSource('722880', tmp_dir)
     ws.client = MockWeatherClient()
     return ws
 
@@ -46,7 +46,7 @@ def mock_isd_weather_source():
 @pytest.fixture
 def mock_tmy3_weather_source():
     tmp_dir = tempfile.mkdtemp()
-    ws = TMY3WeatherSource("724838", tmp_dir, preload=False)
+    ws = TMY3WeatherSource('724838', tmp_dir, preload=False)
     ws.client = MockWeatherClient()
     ws._load_data()
     return ws
@@ -54,26 +54,26 @@ def mock_tmy3_weather_source():
 
 @pytest.fixture
 def site():
-    return ZIPCodeSite("02138")
+    return ZIPCodeSite('02138')
 
 
 @pytest.fixture
 def modeling_period_set():
     modeling_period_1 = ModelingPeriod(
-        "BASELINE",
+        'BASELINE',
         end_date=datetime(2014, 1, 1, tzinfo=pytz.UTC),
     )
     modeling_period_2 = ModelingPeriod(
-        "REPORTING",
+        'REPORTING',
         start_date=datetime(2014, 1, 1, tzinfo=pytz.UTC),
     )
     modeling_periods = {
-        "modeling_period_1": modeling_period_1,
-        "modeling_period_2": modeling_period_2,
+        'modeling_period_1': modeling_period_1,
+        'modeling_period_2': modeling_period_2,
     }
 
     grouping = [
-        ("modeling_period_1", "modeling_period_2"),
+        ('modeling_period_1', 'modeling_period_2'),
     ]
 
     return ModelingPeriodSet(modeling_periods, grouping)
@@ -88,29 +88,29 @@ def test_basic_usage(energy_trace, site, modeling_period_set,
                              weather_source=mock_isd_weather_source,
                              weather_normal_source=mock_tmy3_weather_source)
 
-    assert results["status"] == "SUCCESS"
-    assert results["failure_message"] is None
-    assert len(results["logs"]) == 2
+    assert results['status'] == 'SUCCESS'
+    assert results['failure_message'] is None
+    assert len(results['logs']) == 2
 
-    assert results["eemeter_version"] == '0.4.9'
-    assert results["model_class"] == 'SeasonalElasticNetCVModel'
-    assert results["model_kwargs"] is not None
-    assert results["formatter_class"] == 'ModelDataFormatter'
-    assert results["formatter_kwargs"] is not None
+    assert results['eemeter_version'] == '0.4.9'
+    assert results['model_class'] == 'SeasonalElasticNetCVModel'
+    assert results['model_kwargs'] is not None
+    assert results['formatter_class'] == 'ModelDataFormatter'
+    assert results['formatter_kwargs'] is not None
 
-    assert results["modeled_energy_trace"] is not None
+    assert results['modeled_energy_trace'] is not None
 
-    assert len(results["derivatives"]) == 2
-    results["derivatives"][0].interpretation == "annualized_weather_normal"
-    results["derivatives"][0].baseline.label == "modeling_period_1"
-    results["derivatives"][0].reporting.label == "modeling_period_2"
-    results["derivatives"][0].baseline.value > 0
-    results["derivatives"][0].reporting.value > 0
-    results["derivatives"][1].interpretation == "gross_predicted"
-    results["derivatives"][1].baseline.label == "modeling_period_1"
-    results["derivatives"][1].reporting.label == "modeling_period_2"
-    results["derivatives"][1].baseline.value > 0
-    results["derivatives"][1].reporting.value > 0
+    assert len(results['derivatives']) == 2
+    results['derivatives'][0].interpretation == 'annualized_weather_normal'
+    results['derivatives'][0].baseline.label == 'modeling_period_1'
+    results['derivatives'][0].reporting.label == 'modeling_period_2'
+    results['derivatives'][0].baseline.value > 0
+    results['derivatives'][0].reporting.value > 0
+    results['derivatives'][1].interpretation == 'gross_predicted'
+    results['derivatives'][1].baseline.label == 'modeling_period_1'
+    results['derivatives'][1].reporting.label == 'modeling_period_2'
+    results['derivatives'][1].baseline.value > 0
+    results['derivatives'][1].reporting.value > 0
 
-    assert results["weather_source_station"] == '722880'
-    assert results["weather_normal_source_station"] == '724838'
+    assert results['weather_source_station'] == '722880'
+    assert results['weather_normal_source_station'] == '724838'

--- a/tests/ee/test_energy_efficiency_meter_trace_centric.py
+++ b/tests/ee/test_energy_efficiency_meter_trace_centric.py
@@ -89,17 +89,17 @@ def test_basic_usage(meter_input, mock_isd_weather_source,
     assert results['modeled_energy_trace'] is not None
 
     assert len(results['derivatives']) == 2
-    assert results['derivatives'][0].interpretation == \
+    assert results['derivatives'][0]["interpretation"] == \
         'annualized_weather_normal'
-    assert results['derivatives'][0].baseline.label == 'baseline'
-    assert results['derivatives'][0].reporting.label == 'reporting'
-    assert results['derivatives'][0].baseline.value > 0
-    assert results['derivatives'][0].reporting.value > 0
-    assert results['derivatives'][1].interpretation == 'gross_predicted'
-    assert results['derivatives'][1].baseline.label == 'baseline'
-    assert results['derivatives'][1].reporting.label == 'reporting'
-    assert results['derivatives'][1].baseline.value > 0
-    assert results['derivatives'][1].reporting.value > 0
+    assert results['derivatives'][0]["baseline"]["label"] == 'baseline'
+    assert results['derivatives'][0]["reporting"]["label"] == 'reporting'
+    assert results['derivatives'][0]["baseline"]["value"] > 0
+    assert results['derivatives'][0]["reporting"]["value"] > 0
+    assert results['derivatives'][1]["interpretation"] == 'gross_predicted'
+    assert results['derivatives'][1]["baseline"]["label"] == 'baseline'
+    assert results['derivatives'][1]["reporting"]["label"] == "reporting"
+    assert results['derivatives'][1]["baseline"]["value"] > 0
+    assert results['derivatives'][1]["reporting"]["value"] > 0
 
     assert results['weather_source_station'] == '722880'
     assert results['weather_normal_source_station'] == '724838'

--- a/tests/ee/test_energy_efficiency_meter_trace_centric.py
+++ b/tests/ee/test_energy_efficiency_meter_trace_centric.py
@@ -20,23 +20,43 @@ from eemeter.weather import ISDWeatherSource
 
 
 @pytest.fixture
-def daily_data():
-    index = pd.date_range('2012-01-01', periods=365*4, freq='D', tz=pytz.UTC)
-    data = {
-        'value': np.tile(1, (365 * 4,)),
-        'estimated': np.tile(False, (365 * 4,))
+def meter_input():
+
+    record_starts = pd.date_range('2012-01-01', periods=365*4, freq='D',
+                                  tz=pytz.UTC)
+
+    records = [
+        {
+            "start": dt.isoformat(),
+            "value": 1.0,
+            "estimated": False
+        } for dt in record_starts
+    ]
+
+    meter_input = {
+        "type": "SINGLE_TRACE_SIMPLE_PROJECT",
+        "trace": {
+            "type": "ARBITRARY_START",
+            "interpretation": "NATURAL_GAS_CONSUMPTION_SUPPLIED",
+            "unit": "therm",
+            "records": records
+        },
+        "project": {
+            "type": "PROJECT_WITH_SINGLE_MODELING_PERIOD_GROUP",
+            "zipcode": "91104",
+            "modeling_period_group": {
+                "baseline_period": {
+                    "start": None,
+                    "end": "2014-01-01T00:00:00+00:00"
+                },
+                "reporting_period": {
+                    "start": "2014-02-01T00:00:00+00:00",
+                    "end": None
+                }
+            }
+        }
     }
-    return pd.DataFrame(data, index=index, columns=['value', 'estimated'])
-
-
-@pytest.fixture
-def energy_trace(daily_data):
-    return EnergyTrace('ELECTRICITY_CONSUMPTION_SUPPLIED',
-                       data=daily_data, unit='kWh')
-
-@pytest.fixture
-def placeholder_trace():
-    return EnergyTrace('ELECTRICITY_CONSUMPTION_SUPPLIED', placeholder=True)
+    return meter_input
 
 
 @pytest.fixture
@@ -56,39 +76,12 @@ def mock_tmy3_weather_source():
     return ws
 
 
-@pytest.fixture
-def site():
-    return ZIPCodeSite('02138')
-
-
-@pytest.fixture
-def modeling_period_set():
-    modeling_period_1 = ModelingPeriod(
-        'BASELINE',
-        end_date=datetime(2014, 1, 1, tzinfo=pytz.UTC),
-    )
-    modeling_period_2 = ModelingPeriod(
-        'REPORTING',
-        start_date=datetime(2014, 1, 1, tzinfo=pytz.UTC),
-    )
-    modeling_periods = {
-        'modeling_period_1': modeling_period_1,
-        'modeling_period_2': modeling_period_2,
-    }
-
-    grouping = [
-        ('modeling_period_1', 'modeling_period_2'),
-    ]
-
-    return ModelingPeriodSet(modeling_periods, grouping)
-
-
-def test_basic_usage(energy_trace, site, modeling_period_set,
-                     mock_isd_weather_source, mock_tmy3_weather_source):
+def test_basic_usage(meter_input, mock_isd_weather_source,
+                     mock_tmy3_weather_source):
 
     meter = EnergyEfficiencyMeterTraceCentric()
 
-    results = meter.evaluate(energy_trace, site, modeling_period_set,
+    results = meter.evaluate(meter_input,
                              weather_source=mock_isd_weather_source,
                              weather_normal_source=mock_tmy3_weather_source)
 
@@ -105,28 +98,16 @@ def test_basic_usage(energy_trace, site, modeling_period_set,
     assert results['modeled_energy_trace'] is not None
 
     assert len(results['derivatives']) == 2
-    results['derivatives'][0].interpretation == 'annualized_weather_normal'
-    results['derivatives'][0].baseline.label == 'modeling_period_1'
-    results['derivatives'][0].reporting.label == 'modeling_period_2'
-    results['derivatives'][0].baseline.value > 0
-    results['derivatives'][0].reporting.value > 0
-    results['derivatives'][1].interpretation == 'gross_predicted'
-    results['derivatives'][1].baseline.label == 'modeling_period_1'
-    results['derivatives'][1].reporting.label == 'modeling_period_2'
-    results['derivatives'][1].baseline.value > 0
-    results['derivatives'][1].reporting.value > 0
+    assert results['derivatives'][0].interpretation == 'annualized_weather_normal'
+    assert results['derivatives'][0].baseline.label == 'baseline'
+    assert results['derivatives'][0].reporting.label == 'reporting'
+    assert results['derivatives'][0].baseline.value > 0
+    assert results['derivatives'][0].reporting.value > 0
+    assert results['derivatives'][1].interpretation == 'gross_predicted'
+    assert results['derivatives'][1].baseline.label == 'baseline'
+    assert results['derivatives'][1].reporting.label == 'reporting'
+    assert results['derivatives'][1].baseline.value > 0
+    assert results['derivatives'][1].reporting.value > 0
 
     assert results['weather_source_station'] == '722880'
     assert results['weather_normal_source_station'] == '724838'
-
-def test_with_placeholder_trace(placeholder_trace, site, modeling_period_set):
-    meter = EnergyEfficiencyMeterTraceCentric()
-
-    results = meter.evaluate(placeholder_trace, site, modeling_period_set)
-    assert results['status'] == 'SUCCESS'
-    assert results['failure_message'] is None
-    assert len(results['logs']) == 3
-    assert len(results['derivatives']) == 0
-
-    assert results['weather_source_station'] == '994971'
-    assert results['weather_normal_source_station'] == '725090'

--- a/tests/ee/test_energy_efficiency_meter_trace_centric.py
+++ b/tests/ee/test_energy_efficiency_meter_trace_centric.py
@@ -1,5 +1,4 @@
-import tempfile
-from datetime import datetime
+import tempfile from datetime import datetime
 
 import numpy as np
 import pandas as pd
@@ -33,6 +32,10 @@ def daily_data():
 def energy_trace(daily_data):
     return EnergyTrace('ELECTRICITY_CONSUMPTION_SUPPLIED',
                        data=daily_data, unit='kWh')
+
+@pytest.fixture
+def placeholder_trace():
+    return EnergyTrace('ELECTRICITY_CONSUMPTION_SUPPLIED', placeholder=True)
 
 
 @pytest.fixture
@@ -92,7 +95,7 @@ def test_basic_usage(energy_trace, site, modeling_period_set,
     assert results['failure_message'] is None
     assert len(results['logs']) == 2
 
-    assert results['eemeter_version'] == '0.4.9'
+    assert results['eemeter_version'] is not None
     assert results['model_class'] == 'SeasonalElasticNetCVModel'
     assert results['model_kwargs'] is not None
     assert results['formatter_class'] == 'ModelDataFormatter'
@@ -114,3 +117,15 @@ def test_basic_usage(energy_trace, site, modeling_period_set,
 
     assert results['weather_source_station'] == '722880'
     assert results['weather_normal_source_station'] == '724838'
+
+def test_with_placeholder_trace(placeholder_trace, site, modeling_period_set):
+    meter = EnergyEfficiencyMeterTraceCentric()
+
+    results = meter.evaluate(placeholder_trace, site, modeling_period_set)
+    assert results['status'] == 'SUCCESS'
+    assert results['failure_message'] is None
+    assert len(results['logs']) == 3
+    assert len(results['derivatives']) == 0
+
+    assert results['weather_source_station'] == '994971'
+    assert results['weather_normal_source_station'] == '725090'

--- a/tests/ee/test_energy_efficiency_meter_trace_centric.py
+++ b/tests/ee/test_energy_efficiency_meter_trace_centric.py
@@ -1,18 +1,9 @@
 import tempfile
-from datetime import datetime
 
-import numpy as np
 import pandas as pd
 import pytest
 import pytz
 
-from eemeter.structures import (
-    ZIPCodeSite,
-    EnergyTrace,
-    ModelingPeriod,
-    ModelingPeriodSet,
-)
-from eemeter.modeling.split import SplitModeledEnergyTrace
 from eemeter.ee.meter import EnergyEfficiencyMeterTraceCentric
 from eemeter.testing.mocks import MockWeatherClient
 from eemeter.weather import TMY3WeatherSource
@@ -98,7 +89,8 @@ def test_basic_usage(meter_input, mock_isd_weather_source,
     assert results['modeled_energy_trace'] is not None
 
     assert len(results['derivatives']) == 2
-    assert results['derivatives'][0].interpretation == 'annualized_weather_normal'
+    assert results['derivatives'][0].interpretation == \
+        'annualized_weather_normal'
     assert results['derivatives'][0].baseline.label == 'baseline'
     assert results['derivatives'][0].reporting.label == 'reporting'
     assert results['derivatives'][0].baseline.value > 0

--- a/tests/ee/test_energy_efficiency_meter_trace_centric.py
+++ b/tests/ee/test_energy_efficiency_meter_trace_centric.py
@@ -99,7 +99,18 @@ def test_basic_usage(energy_trace, site, modeling_period_set,
     assert results["formatter_kwargs"] is not None
 
     assert results["modeled_energy_trace"] is not None
+
     assert len(results["derivatives"]) == 2
+    results["derivatives"][0].interpretation == "annualized_weather_normal"
+    results["derivatives"][0].baseline.label == "modeling_period_1"
+    results["derivatives"][0].reporting.label == "modeling_period_2"
+    results["derivatives"][0].baseline.value > 0
+    results["derivatives"][0].reporting.value > 0
+    results["derivatives"][1].interpretation == "gross_predicted"
+    results["derivatives"][1].baseline.label == "modeling_period_1"
+    results["derivatives"][1].reporting.label == "modeling_period_2"
+    results["derivatives"][1].baseline.value > 0
+    results["derivatives"][1].reporting.value > 0
 
     assert results["weather_source_station"] == '722880'
     assert results["weather_normal_source_station"] == '724838'

--- a/tests/ee/test_energy_efficiency_meter_trace_centric.py
+++ b/tests/ee/test_energy_efficiency_meter_trace_centric.py
@@ -107,3 +107,15 @@ def test_basic_usage(meter_input, mock_isd_weather_source,
 
     assert results['weather_source_station'] == '722880'
     assert results['weather_normal_source_station'] == '724838'
+
+
+def test_bad_meter_input(mock_isd_weather_source, mock_tmy3_weather_source):
+
+    meter = EnergyEfficiencyMeterTraceCentric()
+
+    results = meter.evaluate({},
+                             weather_source=mock_isd_weather_source,
+                             weather_normal_source=mock_tmy3_weather_source)
+
+    assert results['status'] == 'FAILURE'
+    assert results['failure_message'].startswith("Meter input")

--- a/tests/ee/test_energy_efficiency_meter_trace_centric.py
+++ b/tests/ee/test_energy_efficiency_meter_trace_centric.py
@@ -1,4 +1,5 @@
-import tempfile from datetime import datetime
+import tempfile
+from datetime import datetime
 
 import numpy as np
 import pandas as pd

--- a/tests/ee/test_energy_efficiency_meter_trace_centric.py
+++ b/tests/ee/test_energy_efficiency_meter_trace_centric.py
@@ -89,13 +89,17 @@ def test_basic_usage(meter_input, mock_isd_weather_source,
     assert results['modeled_energy_trace'] is not None
 
     assert len(results['derivatives']) == 2
-    assert results['derivatives'][0]["interpretation"] == \
+    assert results['derivatives'][0]["derivative_interpretation"] == \
         'annualized_weather_normal'
+    assert results['derivatives'][0]["trace_interpretation"] == \
+        'NATURAL_GAS_CONSUMPTION_SUPPLIED'
+    assert results['derivatives'][0]["unit"] == 'THERM'
     assert results['derivatives'][0]["baseline"]["label"] == 'baseline'
     assert results['derivatives'][0]["reporting"]["label"] == 'reporting'
     assert results['derivatives'][0]["baseline"]["value"] > 0
     assert results['derivatives'][0]["reporting"]["value"] > 0
-    assert results['derivatives'][1]["interpretation"] == 'gross_predicted'
+    assert results['derivatives'][1]["derivative_interpretation"] == \
+        'gross_predicted'
     assert results['derivatives'][1]["baseline"]["label"] == 'baseline'
     assert results['derivatives'][1]["reporting"]["label"] == "reporting"
     assert results['derivatives'][1]["baseline"]["value"] > 0

--- a/tests/ee/test_energy_efficiency_meter_trace_centric.py
+++ b/tests/ee/test_energy_efficiency_meter_trace_centric.py
@@ -1,0 +1,105 @@
+import tempfile
+from datetime import datetime
+
+import numpy as np
+import pandas as pd
+import pytest
+import pytz
+
+from eemeter.structures import (
+    ZIPCodeSite,
+    EnergyTrace,
+    ModelingPeriod,
+    ModelingPeriodSet,
+)
+from eemeter.modeling.split import SplitModeledEnergyTrace
+from eemeter.ee.meter import EnergyEfficiencyMeterTraceCentric
+from eemeter.testing.mocks import MockWeatherClient
+from eemeter.weather import TMY3WeatherSource
+from eemeter.weather import ISDWeatherSource
+
+
+@pytest.fixture
+def daily_data():
+    index = pd.date_range('2012-01-01', periods=365*4, freq='D', tz=pytz.UTC)
+    data = {
+        "value": np.tile(1, (365 * 4,)),
+        "estimated": np.tile(False, (365 * 4,))
+    }
+    return pd.DataFrame(data, index=index, columns=["value", "estimated"])
+
+
+@pytest.fixture
+def energy_trace(daily_data):
+    return EnergyTrace('ELECTRICITY_CONSUMPTION_SUPPLIED',
+                       data=daily_data, unit='kWh')
+
+
+@pytest.fixture
+def mock_isd_weather_source():
+    tmp_dir = tempfile.mkdtemp()
+    ws = ISDWeatherSource("722880", tmp_dir)
+    ws.client = MockWeatherClient()
+    return ws
+
+
+@pytest.fixture
+def mock_tmy3_weather_source():
+    tmp_dir = tempfile.mkdtemp()
+    ws = TMY3WeatherSource("724838", tmp_dir, preload=False)
+    ws.client = MockWeatherClient()
+    ws._load_data()
+    return ws
+
+
+@pytest.fixture
+def site():
+    return ZIPCodeSite("02138")
+
+
+@pytest.fixture
+def modeling_period_set():
+    modeling_period_1 = ModelingPeriod(
+        "BASELINE",
+        end_date=datetime(2014, 1, 1, tzinfo=pytz.UTC),
+    )
+    modeling_period_2 = ModelingPeriod(
+        "REPORTING",
+        start_date=datetime(2014, 1, 1, tzinfo=pytz.UTC),
+    )
+    modeling_periods = {
+        "modeling_period_1": modeling_period_1,
+        "modeling_period_2": modeling_period_2,
+    }
+
+    grouping = [
+        ("modeling_period_1", "modeling_period_2"),
+    ]
+
+    return ModelingPeriodSet(modeling_periods, grouping)
+
+
+def test_basic_usage(energy_trace, site, modeling_period_set,
+                     mock_isd_weather_source, mock_tmy3_weather_source):
+
+    meter = EnergyEfficiencyMeterTraceCentric()
+
+    results = meter.evaluate(energy_trace, site, modeling_period_set,
+                             weather_source=mock_isd_weather_source,
+                             weather_normal_source=mock_tmy3_weather_source)
+
+    assert results["status"] == "SUCCESS"
+    assert results["failure_message"] is None
+    assert len(results["logs"]) == 2
+
+    assert results["eemeter_version"] == '0.4.9'
+    assert results["model_class"] == 'SeasonalElasticNetCVModel'
+    assert results["model_kwargs"] is not None
+    assert results["formatter_class"] == 'ModelDataFormatter'
+    assert results["formatter_kwargs"] is not None
+
+    assert results["modeled_energy_trace"] is not None
+    assert len(results["derivatives"]) == 2
+
+    assert results["weather_source_station"] == '722880'
+    assert results["weather_normal_source_station"] == '724838'

--- a/tests/ee/test_gross_predicted.py
+++ b/tests/ee/test_gross_predicted.py
@@ -52,3 +52,7 @@ def test_basic_usage(mock_isd_weather_source,
         output_end_date['gross_predicted'][0] <
         output_no_end_date['gross_predicted'][0]
     )
+
+    serialized = output_end_date['gross_predicted'][4]
+    assert len(serialized) == 547
+    assert serialized['2015-01-01T00:00:00+00:00'] == 32.0

--- a/tests/ee/test_gross_predicted.py
+++ b/tests/ee/test_gross_predicted.py
@@ -46,7 +46,7 @@ def test_basic_usage(mock_isd_weather_source,
         formatter, model, mock_isd_weather_source,
         reporting_period_no_end_date)
 
-    assert_allclose(output_end_date['gross_predicted'],
+    assert_allclose(output_end_date['gross_predicted'][:4],
                     (547, 23.388031127053, 23.388031127053, 547))
     assert (
         output_end_date['gross_predicted'][0] <

--- a/tests/io/test_deserialize_aggregation_input.py
+++ b/tests/io/test_deserialize_aggregation_input.py
@@ -1,0 +1,182 @@
+import pytest
+
+from eemeter.io.serializers import deserialize_aggregation_input
+
+@pytest.fixture
+def aggregation_input():
+    aggregation_input = {
+        "type": "BASIC_AGGREGATION",
+        "aggregation_interpretation": "SUM",
+        "trace_interpretation": "NATURAL_GAS_CONSUMPTION_SUPPLIED",
+        "derivative_interpretation": "annualized_weather_normal",
+        "derivatives": {
+            "type": "DERIVATIVE_PAIRS",
+            "derivative_pairs": [
+                {
+                    "label": 1,
+                    "derivative_interpretation": "annualized_weather_normal",
+                    "trace_interpretation": "NATURAL_GAS_CONSUMPTION_SUPPLIED",
+                    "unit": "therm",
+                    "baseline_value": 12.7673693526363,
+                    "baseline_lower": 6.64513428655014,
+                    "baseline_upper": 16.6902599327546,
+                    "baseline_n": 365.0,
+                    "reporting_value": 10.4456308079608,
+                    "reporting_lower": 6.87143931976653,
+                    "reporting_upper": 19.4891794773991,
+                    "reporting_n": 365.0
+                },
+                {
+                    "label": 3,
+                    "derivative_interpretation": "annualized_weather_normal",
+                    "trace_interpretation": "NATURAL_GAS_CONSUMPTION_SUPPLIED",
+                    "unit": "therm",
+                    "baseline_value": 12.7673693526363,
+                    "baseline_lower": 6.64513428655014,
+                    "baseline_upper": 16.6902599327546,
+                    "baseline_n": 365.0,
+                    "reporting_value": 10.4456308079608,
+                    "reporting_lower": 6.87143931976653,
+                    "reporting_upper": 19.4891794773991,
+                    "reporting_n": 365.0
+                }
+            ]
+        }
+    }
+    return aggregation_input
+
+
+def test_basic_usage(aggregation_input):
+    result = deserialize_aggregation_input(aggregation_input)
+
+    assert result['aggregation_interpretation'] is not None
+    assert result['derivative_interpretation'] is not None
+    assert result['trace_interpretation'] is not None
+
+    assert result['baseline_default_value'] is None
+    assert result['reporting_default_value'] is None
+
+    assert result['derivative_pairs'] is not None
+
+
+def test_no_type(aggregation_input):
+    del aggregation_input['type']
+
+    result = deserialize_aggregation_input(aggregation_input)
+
+    assert result["error"].startswith('Serialization "type"')
+
+
+def test_unrecognized_type(aggregation_input):
+    aggregation_input['type'] = "UNKNOWN"
+
+    result = deserialize_aggregation_input(aggregation_input)
+
+    assert result["error"].startswith('Serialization type "UNKNOWN"')
+
+
+def test_no_aggregation_interpretation(aggregation_input):
+    del aggregation_input['aggregation_interpretation']
+
+    result = deserialize_aggregation_input(aggregation_input)
+
+    assert result["error"].startswith('For serialization')
+
+
+def test_no_trace_interpretation(aggregation_input):
+    del aggregation_input['trace_interpretation']
+
+    result = deserialize_aggregation_input(aggregation_input)
+
+    assert result["error"].startswith('For serialization')
+
+
+def test_no_derivative_interpretation(aggregation_input):
+    del aggregation_input['derivative_interpretation']
+
+    result = deserialize_aggregation_input(aggregation_input)
+
+    assert result["error"].startswith('For serialization')
+
+
+def test_no_derivatives(aggregation_input):
+    del aggregation_input['derivatives']
+
+    result = deserialize_aggregation_input(aggregation_input)
+
+    assert result["error"].startswith('For serialization')
+
+
+def test_bad_baseline_default(aggregation_input):
+    aggregation_input['baseline_default_value'] = {}
+    result = deserialize_aggregation_input(aggregation_input)
+    assert result["error"].startswith('Serialization')
+
+    aggregation_input['baseline_default_value'] = {"type":"Unknown"}
+    result = deserialize_aggregation_input(aggregation_input)
+    assert result["error"].startswith('Serialization')
+
+    aggregation_input['baseline_default_value'] = {
+        "type": "SIMPLE_DEFAULT",
+        "value": None,
+        "lower": None,
+        "upper": None,
+    }
+    result = deserialize_aggregation_input(aggregation_input)
+    assert result["error"].startswith('Missing')
+
+    aggregation_input['baseline_default_value'] = {
+        "type": "SIMPLE_DEFAULT",
+        "value": None,
+        "lower": None,
+        "upper": None,
+        "n": None,
+    }
+    result = deserialize_aggregation_input(aggregation_input)
+    assert result["baseline_default_value"] is not None
+
+def test_bad_reporting_default(aggregation_input):
+
+    aggregation_input['reporting_default_value'] = {}
+    result = deserialize_aggregation_input(aggregation_input)
+    assert result["error"].startswith('Serialization')
+
+    aggregation_input['reporting_default_value'] = {"type":"Unknown"}
+    result = deserialize_aggregation_input(aggregation_input)
+    assert result["error"].startswith('Serialization')
+
+    aggregation_input['reporting_default_value'] = {
+        "type": "SIMPLE_DEFAULT",
+        "value": None,
+        "lower": None,
+        "upper": None,
+    }
+    result = deserialize_aggregation_input(aggregation_input)
+    assert result["error"].startswith('Missing')
+
+    aggregation_input['reporting_default_value'] = {
+        "type": "SIMPLE_DEFAULT",
+        "value": None,
+        "lower": None,
+        "upper": None,
+        "n": None,
+    }
+    result = deserialize_aggregation_input(aggregation_input)
+    assert result["reporting_default_value"] is not None
+
+
+def test_bad_derivatives(aggregation_input):
+
+    aggregation_input['derivatives'] = {}
+    result = deserialize_aggregation_input(aggregation_input)
+    assert result["error"].startswith('Serialization')
+
+    aggregation_input['derivatives'] = {"type":"Unknown"}
+    result = deserialize_aggregation_input(aggregation_input)
+    assert result["error"].startswith('Serialization')
+
+    aggregation_input['derivatives'] = {
+        "type": "DERIVATIVE_PAIRS",
+    }
+    result = deserialize_aggregation_input(aggregation_input)
+    assert result["error"].startswith('For serialization')

--- a/tests/io/test_deserialize_meter_input.py
+++ b/tests/io/test_deserialize_meter_input.py
@@ -1,7 +1,6 @@
 import pytest
 import pandas as pd
 import pytz
-from copy import deepcopy
 
 from eemeter.structures import (
     EnergyTrace,
@@ -47,6 +46,7 @@ def meter_input():
     }
     return meter_input
 
+
 def test_basic_usage(meter_input):
     result = deserialize_meter_input(meter_input)
     assert isinstance(result["trace"], EnergyTrace)
@@ -55,50 +55,60 @@ def test_basic_usage(meter_input):
     assert isinstance(result["project"]["zipcode"],
                       str)
 
+
 def test_missing_type(meter_input):
     del meter_input["type"]
     result = deserialize_meter_input(meter_input)
     assert "type" in result["error"]
+
 
 def test_missing_trace(meter_input):
     del meter_input["trace"]
     result = deserialize_meter_input(meter_input)
     assert "trace" in result["error"]
 
+
 def test_missing_trace_type(meter_input):
     del meter_input["trace"]["type"]
     result = deserialize_meter_input(meter_input)
     assert "type" in result["error"]
+
 
 def test_missing_trace_interpretation(meter_input):
     del meter_input["trace"]["interpretation"]
     result = deserialize_meter_input(meter_input)
     assert "interpretation" in result["error"]
 
+
 def test_missing_trace_unit(meter_input):
     del meter_input["trace"]["unit"]
     result = deserialize_meter_input(meter_input)
     assert "unit" in result["error"]
+
 
 def test_missing_trace_records(meter_input):
     del meter_input["trace"]["records"]
     result = deserialize_meter_input(meter_input)
     assert "records" in result["error"]
 
+
 def test_missing_project(meter_input):
     del meter_input["project"]
     result = deserialize_meter_input(meter_input)
     assert "project" in result["error"]
+
 
 def test_missing_project_type(meter_input):
     del meter_input["project"]
     result = deserialize_meter_input(meter_input)
     assert "type" in result["error"]
 
+
 def test_missing_project_zipcode(meter_input):
     del meter_input["project"]["zipcode"]
     result = deserialize_meter_input(meter_input)
     assert "zipcode" in result["error"]
+
 
 def test_missing_project_modeling_period_group(meter_input):
     del meter_input["project"]["modeling_period_group"]

--- a/tests/io/test_deserialize_meter_input.py
+++ b/tests/io/test_deserialize_meter_input.py
@@ -1,0 +1,106 @@
+import pytest
+import pandas as pd
+import pytz
+from copy import deepcopy
+
+from eemeter.structures import (
+    EnergyTrace,
+    ModelingPeriodSet,
+)
+
+from eemeter.io.serializers import deserialize_meter_input
+
+
+@pytest.fixture
+def meter_input():
+    meter_input = {
+        "type": "SINGLE_TRACE_SIMPLE_PROJECT",
+        "trace": {
+            "type": "ARBITRARY_START",
+            "interpretation": "NATURAL_GAS_CONSUMPTION_SUPPLIED",
+            "unit": "therm",
+            "records": [
+                {
+                    "start": dt.isoformat(),
+                    "value": 1.0,
+                    "estimated": False
+                }
+
+                for dt in pd.date_range(start="2010-01-01", end="2012-01-01",
+                                        freq="MS", tz=pytz.UTC)
+            ]
+        },
+        "project": {
+            "type": "PROJECT_WITH_SINGLE_MODELING_PERIOD_GROUP",
+            "zipcode": "91104",
+            "modeling_period_group": {
+                "baseline_period": {
+                    "start": None,
+                    "end": "2012-01-01T00:00:00+00:00"
+                },
+                "reporting_period": {
+                    "start": "2012-02-01T00:00:00+00:00",
+                    "end": None
+                }
+            }
+        }
+    }
+    return meter_input
+
+def test_basic_usage(meter_input):
+    result = deserialize_meter_input(meter_input)
+    assert isinstance(result["trace"], EnergyTrace)
+    assert isinstance(result["project"]["modeling_period_set"],
+                      ModelingPeriodSet)
+    assert isinstance(result["project"]["zipcode"],
+                      str)
+
+def test_missing_type(meter_input):
+    del meter_input["type"]
+    result = deserialize_meter_input(meter_input)
+    assert "type" in result["error"]
+
+def test_missing_trace(meter_input):
+    del meter_input["trace"]
+    result = deserialize_meter_input(meter_input)
+    assert "trace" in result["error"]
+
+def test_missing_trace_type(meter_input):
+    del meter_input["trace"]["type"]
+    result = deserialize_meter_input(meter_input)
+    assert "type" in result["error"]
+
+def test_missing_trace_interpretation(meter_input):
+    del meter_input["trace"]["interpretation"]
+    result = deserialize_meter_input(meter_input)
+    assert "interpretation" in result["error"]
+
+def test_missing_trace_unit(meter_input):
+    del meter_input["trace"]["unit"]
+    result = deserialize_meter_input(meter_input)
+    assert "unit" in result["error"]
+
+def test_missing_trace_records(meter_input):
+    del meter_input["trace"]["records"]
+    result = deserialize_meter_input(meter_input)
+    assert "records" in result["error"]
+
+def test_missing_project(meter_input):
+    del meter_input["project"]
+    result = deserialize_meter_input(meter_input)
+    assert "project" in result["error"]
+
+def test_missing_project_type(meter_input):
+    del meter_input["project"]
+    result = deserialize_meter_input(meter_input)
+    assert "type" in result["error"]
+
+def test_missing_project_zipcode(meter_input):
+    del meter_input["project"]["zipcode"]
+    result = deserialize_meter_input(meter_input)
+    assert "zipcode" in result["error"]
+
+def test_missing_project_modeling_period_group(meter_input):
+    del meter_input["project"]["modeling_period_group"]
+    result = deserialize_meter_input(meter_input)
+    assert "modeling_period_group" in result["error"]

--- a/tests/io/test_serialize_derivative_pairs.py
+++ b/tests/io/test_serialize_derivative_pairs.py
@@ -11,6 +11,7 @@ from eemeter.ee.derivatives import DerivativePair, Derivative
 def derivative_pairs():
     return [
         DerivativePair(
+            "label",
             "ANNUALIZED_WEATHER_NORMAL",
             "ELECTRICITY_CONSUMPTION_SUPPLIED",
             "KWH",
@@ -19,6 +20,7 @@ def derivative_pairs():
             Derivative("2", 10, 6, 6, 5, None),
         ),
         DerivativePair(
+            "label",
             "GROSS_PREDICTED",
             "ELECTRICITY_CONSUMPTION_SUPPLIED",
             "KWH",
@@ -32,6 +34,7 @@ def derivative_pairs():
 def derivative_pairs_badly_formed():
     return [
         DerivativePair(
+            "label",
             "ANNUALIZED_WEATHER_NORMAL",
             "ELECTRICITY_CONSUMPTION_SUPPLIED",
             "KWH",
@@ -40,6 +43,7 @@ def derivative_pairs_badly_formed():
             Derivative("2", 10, 6, 6, 5, None),
         ),
         DerivativePair(
+            "label",
             "GROSS_PREDICTED",
             "ELECTRICITY_CONSUMPTION_SUPPLIED",
             "KWH",
@@ -52,7 +56,8 @@ def derivative_pairs_badly_formed():
 def test_basic_usage(derivative_pairs):
     serialized = serialize_derivative_pairs(derivative_pairs)
     assert len(serialized) == 2
-    assert len(json.dumps(serialized)) == 692
+    assert len(json.dumps(serialized)) == 728
+    assert serialized[0]["label"] == "label"
     assert serialized[0]["derivative_interpretation"] == \
         "ANNUALIZED_WEATHER_NORMAL"
     assert serialized[0]["trace_interpretation"] == \

--- a/tests/io/test_serialize_derivative_pairs.py
+++ b/tests/io/test_serialize_derivative_pairs.py
@@ -12,12 +12,14 @@ def derivative_pairs():
     return [
         DerivativePair(
             "interpretation1",
+            "kWh",
             Derivative("1", 10, 3, 3, 5,
                        OrderedDict([('2011-01-01T00:00:00+00:00', 32.0)])),
             Derivative("2", 10, 6, 6, 5, None),
         ),
         DerivativePair(
             "interpretation2",
+            "kWh",
             Derivative("1", None, None, None, None, None),
             Derivative("2", 10, 8, 8, 5, None),
         ),
@@ -29,12 +31,14 @@ def derivative_pairs_badly_formed():
     return [
         DerivativePair(
             "interpretation1",
+            "kWh",
             Derivative("1", 10, 3, 3, 5,
                        OrderedDict([('2011-01-01T00:00:00+00:00', 32.0)])),
             Derivative("2", 10, 6, 6, 5, None),
         ),
         DerivativePair(
             "interpretation2",
+            "kWh",
             None,
             Derivative("2", 10, 8, 8, 5, None),
         ),
@@ -44,8 +48,9 @@ def derivative_pairs_badly_formed():
 def test_basic_usage(derivative_pairs):
     serialized = serialize_derivative_pairs(derivative_pairs)
     assert len(serialized) == 2
-    assert len(json.dumps(serialized)) == 510
+    assert len(json.dumps(serialized)) == 540
     assert serialized[0]["interpretation"] == "interpretation1"
+    assert serialized[0]["unit"] == "kWh"
     assert serialized[0]["baseline"]["label"] == "1"
     assert serialized[0]["baseline"]["value"] == 10
     assert serialized[0]["baseline"]["lower"] == 3

--- a/tests/io/test_serialize_derivative_pairs.py
+++ b/tests/io/test_serialize_derivative_pairs.py
@@ -18,6 +18,23 @@ def derivative_pairs():
         ),
         DerivativePair(
             "interpretation2",
+            Derivative("1", None, None, None, None, None),
+            Derivative("2", 10, 8, 8, 5, None),
+        ),
+    ]
+
+
+@pytest.fixture
+def derivative_pairs_badly_formed():
+    return [
+        DerivativePair(
+            "interpretation1",
+            Derivative("1", 10, 3, 3, 5,
+                       OrderedDict([('2011-01-01T00:00:00+00:00', 32.0)])),
+            Derivative("2", 10, 6, 6, 5, None),
+        ),
+        DerivativePair(
+            "interpretation2",
             None,
             Derivative("2", 10, 8, 8, 5, None),
         ),
@@ -27,7 +44,7 @@ def derivative_pairs():
 def test_basic_usage(derivative_pairs):
     serialized = serialize_derivative_pairs(derivative_pairs)
     assert len(serialized) == 2
-    assert len(json.dumps(serialized)) == 420
+    assert len(json.dumps(serialized)) == 510
     assert serialized[0]["interpretation"] == "interpretation1"
     assert serialized[0]["baseline"]["label"] == "1"
     assert serialized[0]["baseline"]["value"] == 10
@@ -39,5 +56,9 @@ def test_basic_usage(derivative_pairs):
     assert serialized[0]["reporting"]["demand_fixture"] is None
 
     assert serialized[1]["interpretation"] == "interpretation2"
-    assert serialized[1]["baseline"] is None
+    assert serialized[1]["baseline"]["label"] == "1"
     assert serialized[1]["reporting"]["value"] == 10
+
+def test_badly_formed(derivative_pairs_badly_formed):
+    with pytest.raises(AttributeError):
+        serialized = serialize_derivative_pairs(derivative_pairs_badly_formed)

--- a/tests/io/test_serialize_derivative_pairs.py
+++ b/tests/io/test_serialize_derivative_pairs.py
@@ -11,13 +11,13 @@ def derivative_pairs():
     return [
         DerivativePair(
             "interpretation1",
-            Derivative("1", 10, 3, 3, 5),
-            Derivative("2", 10, 6, 6, 5),
+            Derivative("1", 10, 3, 3, 5, None),
+            Derivative("2", 10, 6, 6, 5, None),
         ),
         DerivativePair(
             "interpretation2",
             None,
-            Derivative("2", 10, 8, 8, 5),
+            Derivative("2", 10, 8, 8, 5, None),
         ),
     ]
 

--- a/tests/io/test_serialize_derivative_pairs.py
+++ b/tests/io/test_serialize_derivative_pairs.py
@@ -11,15 +11,17 @@ from eemeter.ee.derivatives import DerivativePair, Derivative
 def derivative_pairs():
     return [
         DerivativePair(
-            "interpretation1",
-            "kWh",
+            "ANNUALIZED_WEATHER_NORMAL",
+            "ELECTRICITY_CONSUMPTION_SUPPLIED",
+            "KWH",
             Derivative("1", 10, 3, 3, 5,
                        OrderedDict([('2011-01-01T00:00:00+00:00', 32.0)])),
             Derivative("2", 10, 6, 6, 5, None),
         ),
         DerivativePair(
-            "interpretation2",
-            "kWh",
+            "GROSS_PREDICTED",
+            "ELECTRICITY_CONSUMPTION_SUPPLIED",
+            "KWH",
             Derivative("1", None, None, None, None, None),
             Derivative("2", 10, 8, 8, 5, None),
         ),
@@ -30,15 +32,17 @@ def derivative_pairs():
 def derivative_pairs_badly_formed():
     return [
         DerivativePair(
-            "interpretation1",
-            "kWh",
+            "ANNUALIZED_WEATHER_NORMAL",
+            "ELECTRICITY_CONSUMPTION_SUPPLIED",
+            "KWH",
             Derivative("1", 10, 3, 3, 5,
                        OrderedDict([('2011-01-01T00:00:00+00:00', 32.0)])),
             Derivative("2", 10, 6, 6, 5, None),
         ),
         DerivativePair(
-            "interpretation2",
-            "kWh",
+            "GROSS_PREDICTED",
+            "ELECTRICITY_CONSUMPTION_SUPPLIED",
+            "KWH",
             None,
             Derivative("2", 10, 8, 8, 5, None),
         ),
@@ -48,9 +52,12 @@ def derivative_pairs_badly_formed():
 def test_basic_usage(derivative_pairs):
     serialized = serialize_derivative_pairs(derivative_pairs)
     assert len(serialized) == 2
-    assert len(json.dumps(serialized)) == 540
-    assert serialized[0]["interpretation"] == "interpretation1"
-    assert serialized[0]["unit"] == "kWh"
+    assert len(json.dumps(serialized)) == 692
+    assert serialized[0]["derivative_interpretation"] == \
+        "ANNUALIZED_WEATHER_NORMAL"
+    assert serialized[0]["trace_interpretation"] == \
+        "ELECTRICITY_CONSUMPTION_SUPPLIED"
+    assert serialized[0]["unit"] == "KWH"
     assert serialized[0]["baseline"]["label"] == "1"
     assert serialized[0]["baseline"]["value"] == 10
     assert serialized[0]["baseline"]["lower"] == 3
@@ -60,7 +67,7 @@ def test_basic_usage(derivative_pairs):
     assert serialized[0]["reporting"]["value"] == 10
     assert serialized[0]["reporting"]["demand_fixture"] is None
 
-    assert serialized[1]["interpretation"] == "interpretation2"
+    assert serialized[1]["derivative_interpretation"] == "GROSS_PREDICTED"
     assert serialized[1]["baseline"]["label"] == "1"
     assert serialized[1]["reporting"]["value"] == 10
 

--- a/tests/io/test_serialize_derivative_pairs.py
+++ b/tests/io/test_serialize_derivative_pairs.py
@@ -1,0 +1,35 @@
+import json
+
+import pytest
+
+from eemeter.io.serializers.meter_output import serialize_derivative_pairs
+from eemeter.ee.derivatives import DerivativePair, Derivative
+
+
+@pytest.fixture
+def derivative_pairs():
+    return [
+        DerivativePair(
+            "interpretation1",
+            Derivative("1", 10, 3, 3, 5),
+            Derivative("2", 10, 6, 6, 5),
+        ),
+        DerivativePair(
+            "interpretation2",
+            None,
+            Derivative("2", 10, 8, 8, 5),
+        ),
+    ]
+
+
+def test_basic_usage(derivative_pairs):
+    serialized = serialize_derivative_pairs(derivative_pairs)
+    assert len(serialized) == 2
+    assert len(json.dumps(serialized)) == 317
+    assert serialized[0]["interpretation"] == "interpretation1"
+    assert serialized[1]["interpretation"] == "interpretation2"
+
+    assert serialized[0]["baseline"]["value"] == 10
+    assert serialized[0]["reporting"]["value"] == 10
+    assert serialized[1]["baseline"] is None
+    assert serialized[1]["reporting"]["value"] == 10

--- a/tests/io/test_serialize_derivative_pairs.py
+++ b/tests/io/test_serialize_derivative_pairs.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 import json
 
 import pytest
@@ -11,7 +12,8 @@ def derivative_pairs():
     return [
         DerivativePair(
             "interpretation1",
-            Derivative("1", 10, 3, 3, 5, None),
+            Derivative("1", 10, 3, 3, 5,
+                       OrderedDict([('2011-01-01T00:00:00+00:00', 32.0)])),
             Derivative("2", 10, 6, 6, 5, None),
         ),
         DerivativePair(
@@ -25,11 +27,17 @@ def derivative_pairs():
 def test_basic_usage(derivative_pairs):
     serialized = serialize_derivative_pairs(derivative_pairs)
     assert len(serialized) == 2
-    assert len(json.dumps(serialized)) == 317
+    assert len(json.dumps(serialized)) == 420
     assert serialized[0]["interpretation"] == "interpretation1"
-    assert serialized[1]["interpretation"] == "interpretation2"
-
+    assert serialized[0]["baseline"]["label"] == "1"
     assert serialized[0]["baseline"]["value"] == 10
+    assert serialized[0]["baseline"]["lower"] == 3
+    assert serialized[0]["baseline"]["upper"] == 3
+    assert serialized[0]["baseline"]["n"] == 5
+    assert serialized[0]["baseline"]["demand_fixture"] is not None
     assert serialized[0]["reporting"]["value"] == 10
+    assert serialized[0]["reporting"]["demand_fixture"] is None
+
+    assert serialized[1]["interpretation"] == "interpretation2"
     assert serialized[1]["baseline"] is None
     assert serialized[1]["reporting"]["value"] == 10

--- a/tests/io/test_serialize_derivative_pairs.py
+++ b/tests/io/test_serialize_derivative_pairs.py
@@ -76,6 +76,7 @@ def test_basic_usage(derivative_pairs):
     assert serialized[1]["baseline"]["label"] == "1"
     assert serialized[1]["reporting"]["value"] == 10
 
+
 def test_badly_formed(derivative_pairs_badly_formed):
     with pytest.raises(AttributeError):
         serialized = serialize_derivative_pairs(derivative_pairs_badly_formed)

--- a/tests/io/test_serialize_split_modeled_energy_trace.py
+++ b/tests/io/test_serialize_split_modeled_energy_trace.py
@@ -1,0 +1,195 @@
+from datetime import datetime
+import tempfile
+
+import numpy as np
+import pandas as pd
+import pytest
+import pytz
+
+from eemeter.io.serializers import serialize_split_modeled_energy_trace
+from eemeter.structures import (
+    EnergyTrace,
+    ModelingPeriod,
+    ModelingPeriodSet,
+)
+from eemeter.modeling.formatters import (
+    ModelDataFormatter,
+    ModelDataBillingFormatter,
+)
+from eemeter.modeling.models import (
+    SeasonalElasticNetCVModel,
+    BillingElasticNetCVModel,
+)
+from eemeter.modeling.split import SplitModeledEnergyTrace
+from eemeter.testing import MockWeatherClient
+from eemeter.weather import ISDWeatherSource
+
+
+@pytest.fixture
+def daily_trace():
+    data = {
+        "value": np.tile(1, (365,)),
+        "estimated": np.tile(False, (365,)),
+    }
+    columns = ["value", "estimated"]
+    index = pd.date_range('2000-01-01', periods=365, freq='D', tz=pytz.UTC)
+    df = pd.DataFrame(data, index=index, columns=columns)
+    return EnergyTrace("ELECTRICITY_CONSUMPTION_SUPPLIED", df, unit="KWH")
+
+
+@pytest.fixture
+def monthly_trace():
+    data = {
+        "value": np.tile(1, (24,)),
+        "estimated": np.tile(False, (24,)),
+    }
+    columns = ["value", "estimated"]
+    index = pd.date_range('2000-01-01', periods=24, freq='MS', tz=pytz.UTC)
+    df = pd.DataFrame(data, index=index, columns=columns)
+    return EnergyTrace("ELECTRICITY_CONSUMPTION_SUPPLIED", df, unit="KWH")
+
+
+@pytest.fixture
+def mock_isd_weather_source():
+    tmp_dir = tempfile.mkdtemp()
+    ws = ISDWeatherSource("722880", tmp_dir)
+    ws.client = MockWeatherClient()
+    return ws
+
+
+@pytest.fixture
+def modeling_period_set():
+    modeling_period_1 = ModelingPeriod(
+        "BASELINE",
+        end_date=datetime(2000, 9, 1, tzinfo=pytz.UTC),
+    )
+    modeling_period_2 = ModelingPeriod(
+        "REPORTING",
+        start_date=datetime(2001, 1, 1, tzinfo=pytz.UTC),
+    )
+    modeling_periods = {
+        "modeling_period_1": modeling_period_1,
+        "modeling_period_2": modeling_period_2,
+    }
+
+    grouping = [
+        ("modeling_period_1", "modeling_period_2"),
+    ]
+
+    return ModelingPeriodSet(modeling_periods, grouping)
+
+
+@pytest.fixture
+def split_modeled_energy_trace_daily(daily_trace, modeling_period_set, mock_isd_weather_source):
+
+    # create SplitModeledEnergyTrace
+    formatter = ModelDataFormatter('D')
+    model_mapping = {
+        'modeling_period_1': SeasonalElasticNetCVModel(65, 65),
+        'modeling_period_2': SeasonalElasticNetCVModel(65, 65),
+    }
+    smet = SplitModeledEnergyTrace(
+        daily_trace, formatter, model_mapping, modeling_period_set)
+
+    smet.fit(mock_isd_weather_source)
+    return smet
+
+@pytest.fixture
+def split_modeled_energy_trace_monthly(monthly_trace, modeling_period_set, mock_isd_weather_source):
+
+    # create SplitModeledEnergyTrace
+    formatter = ModelDataBillingFormatter()
+    model_mapping = {
+        'modeling_period_1': BillingElasticNetCVModel(65, 65),
+        'modeling_period_2': BillingElasticNetCVModel(65, 65),
+    }
+    smet = SplitModeledEnergyTrace(
+        monthly_trace, formatter, model_mapping, modeling_period_set)
+
+    smet.fit(mock_isd_weather_source)
+    return smet
+
+def test_basic_usage_daily(split_modeled_energy_trace_daily):
+    serialized = serialize_split_modeled_energy_trace(split_modeled_energy_trace_daily)
+
+    fits = serialized["fits"]
+    mp1 = fits["modeling_period_1"]
+    mp2 = fits["modeling_period_2"]
+
+    assert mp1['status'] == "SUCCESS"
+    assert mp1['traceback'] is None
+    assert mp1['input_data'] is not None
+    assert mp1['start_date'] is not None
+    assert mp1['end_date'] is not None
+    assert mp1['n_rows'] is not None
+
+    model_fit = mp1['model_fit']
+    assert model_fit["r2"] is not None
+    assert model_fit["cvrmse"] is not None
+    assert model_fit["rmse"] is not None
+    assert model_fit["lower"] is not None
+    assert model_fit["upper"] is not None
+    assert model_fit["n"] is not None
+    assert model_fit["model_params"] is None
+
+    assert mp2['status'] == "FAILURE"
+    assert mp2['traceback'] is not None
+    assert len(mp2['input_data']) == 0
+    assert mp2['start_date'] is None
+    assert mp2['end_date'] is None
+    assert mp2['n_rows'] is not None
+    assert mp2['model_fit'] is None
+
+    modeling_period_set = serialized["modeling_period_set"]
+    modeling_periods = modeling_period_set["modeling_periods"]
+
+    modeling_period_groups = modeling_period_set["modeling_period_groups"]
+    assert len(modeling_period_groups) == 1
+    assert modeling_period_groups[0]["baseline"] == "modeling_period_1"
+    assert modeling_period_groups[0]["reporting"] == "modeling_period_2"
+
+    assert modeling_periods["modeling_period_1"]["end_date"] == \
+        '2000-09-01T00:00:00+00:00'
+
+def test_basic_usage_monthly(split_modeled_energy_trace_monthly):
+    serialized = serialize_split_modeled_energy_trace(split_modeled_energy_trace_monthly)
+
+    fits = serialized["fits"]
+    mp1 = fits["modeling_period_1"]
+    mp2 = fits["modeling_period_2"]
+
+    assert mp1['status'] == "SUCCESS"
+    assert mp1['traceback'] is None
+    assert mp1['input_data'] is not None
+    assert mp1['start_date'] is not None
+    assert mp1['end_date'] is not None
+    assert mp1['n_rows'] is not None
+
+    model_fit = mp1['model_fit']
+    assert model_fit["r2"] is not None
+    assert model_fit["cvrmse"] is not None
+    assert model_fit["rmse"] is not None
+    assert model_fit["lower"] is not None
+    assert model_fit["upper"] is not None
+    assert model_fit["n"] is not None
+    assert model_fit["model_params"] is None
+
+    assert mp2['status'] == "SUCCESS"
+    assert mp2['traceback'] is None
+    assert len(mp2['input_data']) > 0
+    assert mp2['start_date'] is not None
+    assert mp2['end_date'] is not None
+    assert mp2['n_rows'] is not None
+    assert mp2['model_fit'] is not None
+
+    modeling_period_set = serialized["modeling_period_set"]
+
+    modeling_period_groups = modeling_period_set["modeling_period_groups"]
+    assert len(modeling_period_groups) == 1
+    assert modeling_period_groups[0]["baseline"] == "modeling_period_1"
+    assert modeling_period_groups[0]["reporting"] == "modeling_period_2"
+
+    modeling_periods = modeling_period_set["modeling_periods"]
+
+    assert modeling_periods["modeling_period_1"]["end_date"] == \
+        '2000-09-01T00:00:00+00:00'

--- a/tests/io/test_serialize_split_modeled_energy_trace.py
+++ b/tests/io/test_serialize_split_modeled_energy_trace.py
@@ -138,7 +138,13 @@ def test_basic_usage_daily(split_modeled_energy_trace_daily):
     assert mp2['start_date'] is None
     assert mp2['end_date'] is None
     assert mp2['n_rows'] is not None
-    assert mp2['model_fit'] is None
+    assert mp2['model_fit']['r2'] is None
+    assert mp2['model_fit']['cvrmse'] is None
+    assert mp2['model_fit']['rmse'] is None
+    assert mp2['model_fit']['lower'] is None
+    assert mp2['model_fit']['upper'] is None
+    assert mp2['model_fit']['n'] is None
+    assert mp2['model_fit']['model_params'] is None
 
     modeling_period_set = serialized["modeling_period_set"]
     modeling_periods = modeling_period_set["modeling_periods"]

--- a/tests/io/test_serialize_split_modeled_energy_trace.py
+++ b/tests/io/test_serialize_split_modeled_energy_trace.py
@@ -112,6 +112,9 @@ def split_modeled_energy_trace_monthly(monthly_trace, modeling_period_set, mock_
 def test_basic_usage_daily(split_modeled_energy_trace_daily):
     serialized = serialize_split_modeled_energy_trace(split_modeled_energy_trace_daily)
 
+    type_ = serialized["type"]
+    assert type_ == "SPLIT_MODELED_ENERGY_TRACE"
+
     fits = serialized["fits"]
     mp1 = fits["modeling_period_1"]
     mp2 = fits["modeling_period_2"]

--- a/tests/modeling/test_billing_model.py
+++ b/tests/modeling/test_billing_model.py
@@ -60,4 +60,11 @@ def test_basic_usage(trace, mock_isd_weather_source):
     outputs = model.predict(formatted_predict_data)
     assert outputs.shape == (365,)
 
+    index = pd.date_range('2011-01-01', freq='D', periods=365, tz=pytz.UTC)
+    formatted_predict_data = formatter.create_demand_fixture(
+        index, mock_isd_weather_source)
+
+    outputs = model.predict(formatted_predict_data)
+    assert outputs.shape == (365,)
+
     assert "ModelDataBillingFormatter" in str(ModelDataBillingFormatter)

--- a/tests/modeling/test_split_modeled_energy_trace.py
+++ b/tests/modeling/test_split_modeled_energy_trace.py
@@ -101,9 +101,9 @@ def test_basic_usage(trace, modeling_period_set, mock_isd_weather_source):
         return returnme
 
     mp1_deriv = smet.compute_derivative(
-            'modeling_period_1', callable_, returnme="A")
+            'modeling_period_1', callable_, {"returnme": "A"})
     mp2_deriv = smet.compute_derivative(
-            'modeling_period_2', callable_, returnme="A")
+            'modeling_period_2', callable_, {"returnme": "A"})
 
     assert mp1_deriv == "A"
     assert mp2_deriv is None

--- a/tests/processors/test_get_weather_normal_source.py
+++ b/tests/processors/test_get_weather_normal_source.py
@@ -1,41 +1,29 @@
 import pytest
 
-from eemeter.structures import (
-    Project,
-    ZIPCodeSite,
-    EnergyTraceSet,
-)
+from eemeter.structures import ZIPCodeSite
 
 from eemeter.processors.location import get_weather_normal_source
 
 
 @pytest.fixture
-def project():
-    ets = EnergyTraceSet({})
-    interventions = []
-    site = ZIPCodeSite("91104")
-    project = Project(ets, interventions, site)
-    return project
+def site():
+    return ZIPCodeSite("91104")
 
 
 @pytest.fixture
-def project_bad_zip():
-    ets = EnergyTraceSet({})
-    interventions = []
-    site = ZIPCodeSite("00000")
-    project = Project(ets, interventions, site)
-    return project
+def site_bad_zip():
+    return ZIPCodeSite("00000")
 
 
-def test_basic_usage(project):
+def test_basic_usage(site):
 
-    ws = get_weather_normal_source(project)
+    ws = get_weather_normal_source(site)
 
     assert ws.station == '722880'
 
 
-def test_bad_zip(project_bad_zip):
+def test_bad_zip(site_bad_zip):
 
-    ws = get_weather_normal_source(project_bad_zip)
+    ws = get_weather_normal_source(site_bad_zip)
 
     assert ws is None

--- a/tests/processors/test_get_weather_source.py
+++ b/tests/processors/test_get_weather_source.py
@@ -1,41 +1,29 @@
 import pytest
 
-from eemeter.structures import (
-    Project,
-    ZIPCodeSite,
-    EnergyTraceSet,
-)
+from eemeter.structures import ZIPCodeSite
 
 from eemeter.processors.location import get_weather_source
 
 
 @pytest.fixture
-def project():
-    ets = EnergyTraceSet({})
-    interventions = []
-    site = ZIPCodeSite("91104")
-    project = Project(ets, interventions, site)
-    return project
+def site():
+    return ZIPCodeSite("91104")
 
 
 @pytest.fixture
-def project_bad_zip():
-    ets = EnergyTraceSet({})
-    interventions = []
-    site = ZIPCodeSite("00000")
-    project = Project(ets, interventions, site)
-    return project
+def site_bad_zip():
+    return ZIPCodeSite("00000")
 
 
-def test_basic_usage(project):
+def test_basic_usage(site):
 
-    ws = get_weather_source(project)
+    ws = get_weather_source(site)
 
     assert ws.station == '722880'
 
 
-def test_bad_zip(project_bad_zip):
+def test_bad_zip(site_bad_zip):
 
-    ws = get_weather_source(project_bad_zip)
+    ws = get_weather_source(site_bad_zip)
 
     assert ws is None

--- a/tests/weather/test_tmy3.py
+++ b/tests/weather/test_tmy3.py
@@ -34,6 +34,15 @@ def test_daily_by_index(mock_tmy3_weather_source):
     assert temps.shape == (2,)
     assert_allclose(temps.values, [32, 32])
 
+    # load from cache
+    temps = mock_tmy3_weather_source.indexed_temperatures(index, 'degF')
+
+
+def test_weird_frequency_by_index(mock_tmy3_weather_source):
+    index = pd.date_range('2000-01-01 00:00:00Z', periods=2, freq='5H')
+    with pytest.raises(ValueError):
+        temps = mock_tmy3_weather_source.indexed_temperatures(index, 'degF')
+
 
 def test_cross_year_boundary(mock_tmy3_weather_source):
     index = pd.date_range('1999-12-31 12:00:00Z', periods=2, freq='D')

--- a/tests/weather/test_tmy3.py
+++ b/tests/weather/test_tmy3.py
@@ -34,8 +34,8 @@ def test_daily_by_index(mock_tmy3_weather_source):
     assert temps.shape == (2,)
     assert_allclose(temps.values, [32, 32])
 
-    # load from cache
-    temps = mock_tmy3_weather_source.indexed_temperatures(index, 'degF')
+    # force load from cache
+    mock_tmy3_weather_source._load_data()
 
 
 def test_weird_frequency_by_index(mock_tmy3_weather_source):


### PR DESCRIPTION
Trace-centric meters
---

Changes
 - Adds meter which takes trace, formatter, model, modeling period group, site
  - applies formatter, model, to trace
  - outputs paired derivatives, since these are always treated as pairs

- Adds Aggregator class which can be set up to operate over a trace interpretation with a specific function, which takes derivatives and aggregates them
 - should ensure that derivatives all have the right interpretation
 - removes derivative pairs that don’t meet requirements, reports this as counts
 - applies aggregation function

- Forces serialization before running meter
  - input and output are both serialized forms of trace and project details