### PR TITLE
Add premasked derivative series

### DIFF
--- a/eemeter/modeling/formatters.py
+++ b/eemeter/modeling/formatters.py
@@ -174,8 +174,8 @@ class ModelDataFormatter(FormatterBase):
 
     def get_input_data_mask(self, input_data):
         ''' Boolean list of missing/not missing values:
-            True  => not missing
-            False => missing
+            True  => missing
+            False => not missing
         '''
 
         dts, mask = [], []
@@ -368,8 +368,8 @@ formatter.create_input(energy_trace, weather_source)
 
     def get_input_data_mask(self, input_data):
         ''' Boolean list of missing/not missing values:
-            True  => not missing
-            False => missing
+            True  => missing
+            False => not missing
         '''
         trace_data, temp_data = input_data
         dts = []

--- a/tests/ee/test_energy_efficiency_meter.py
+++ b/tests/ee/test_energy_efficiency_meter.py
@@ -264,7 +264,7 @@ def test_basic_usage_daily(
     assert results['modeled_energy_trace'] is not None
 
     derivatives = results['derivatives']
-    assert len(derivatives) == 22
+    assert len(derivatives) == 26
     assert derivatives[0]['modeling_period_group'] == \
         ('baseline', 'reporting')
     assert derivatives[0]['orderable'] == [None]
@@ -286,6 +286,9 @@ def test_basic_usage_daily(
         'Baseline model minus observed, reporting period',
         'Baseline model, reporting period',
         'Observed, reporting period',
+        'Masked baseline model minus observed, reporting period',
+        'Masked baseline model, reporting period',
+        'Masked observed, reporting period',
 
         'Baseline model, baseline period',
         'Reporting model, reporting period',
@@ -301,6 +304,7 @@ def test_basic_usage_daily(
         'Temperature, baseline period',
         'Temperature, reporting period',
         'Temperature, normal year',
+        'Masked temperature, reporting period',
     ])
 
     for d in derivatives:
@@ -336,7 +340,7 @@ def test_basic_usage_monthly(
     assert results['modeled_energy_trace'] is not None
 
     derivatives = results['derivatives']
-    assert len(derivatives) == 22
+    assert len(derivatives) == 26
     assert derivatives[0]['modeling_period_group'] == \
         ('baseline', 'reporting')
     assert derivatives[0]['orderable'] == [None]
@@ -356,6 +360,9 @@ def test_basic_usage_monthly(
         'Baseline model minus observed, reporting period',
         'Baseline model, reporting period',
         'Observed, reporting period',
+        'Masked baseline model minus observed, reporting period',
+        'Masked baseline model, reporting period',
+        'Masked observed, reporting period',
 
         'Baseline model, baseline period',
         'Reporting model, reporting period',
@@ -371,6 +378,7 @@ def test_basic_usage_monthly(
         'Temperature, baseline period',
         'Temperature, reporting period',
         'Temperature, normal year',
+        'Masked temperature, reporting period',
     ])
 
     for d in derivatives:
@@ -405,7 +413,7 @@ def test_basic_usage_baseline_only(
     assert results['modeled_energy_trace'] is not None
 
     derivatives = results['derivatives']
-    assert len(derivatives) == 13
+    assert len(derivatives) == 15
     assert derivatives[0]['modeling_period_group'] == \
         ('baseline', 'reporting')
     assert derivatives[0]['orderable'] == [None]
@@ -425,6 +433,9 @@ def test_basic_usage_baseline_only(
         # 'Baseline model minus observed, reporting period',
         # 'Baseline model, reporting period',
         'Observed, reporting period',
+        # 'Masked baseline model minus observed, reporting period',
+        # 'Masked baseline model, reporting period',
+        'Masked observed, reporting period',
 
         'Baseline model, baseline period',
         #'Reporting model, reporting period',
@@ -440,6 +451,7 @@ def test_basic_usage_baseline_only(
         'Temperature, baseline period',
         'Temperature, reporting period',
         'Temperature, normal year',
+        'Masked temperature, reporting period',
     ])
 
     for d in derivatives:
@@ -474,7 +486,7 @@ def test_basic_usage_reporting_only(
     assert results['modeled_energy_trace'] is not None
 
     derivatives = results['derivatives']
-    assert len(derivatives) == 13
+    assert len(derivatives) == 15
     assert derivatives[0]['modeling_period_group'] == \
         ('baseline', 'reporting')
     assert derivatives[0]['orderable'] == [None]
@@ -496,6 +508,9 @@ def test_basic_usage_reporting_only(
         # 'Baseline model minus observed, reporting period',
         # 'Baseline model, reporting period',
         'Observed, reporting period',
+        # 'Masked baseline model minus observed, reporting period',
+        # 'Masked baseline model, reporting period',
+        'Masked observed, reporting period',
 
         #'Baseline model, baseline period',
         'Reporting model, reporting period',
@@ -511,6 +526,7 @@ def test_basic_usage_reporting_only(
         'Temperature, baseline period',
         'Temperature, reporting period',
         'Temperature, normal year',
+        'Masked temperature, reporting period',
     ])
 
     for d in derivatives:
@@ -574,7 +590,7 @@ def test_bad_zipcode(meter_input_bad_zipcode):
     assert results['interval'] is None
 
     derivatives = results['derivatives']
-    assert len(derivatives) == 7
+    assert len(derivatives) == 8
 
     source_series = set([d['series'] for d in derivatives])
     assert source_series == set([
@@ -591,6 +607,9 @@ def test_bad_zipcode(meter_input_bad_zipcode):
         # 'Baseline model minus observed, reporting period',
         # 'Baseline model, reporting period',
         'Observed, reporting period',
+        # 'Masked baseline model minus observed, reporting period',
+        # 'Masked baseline model, reporting period',
+        'Masked observed, reporting period',
 
         #'Baseline model, baseline period',
         #'Reporting model, reporting period',
@@ -602,9 +621,12 @@ def test_bad_zipcode(meter_input_bad_zipcode):
 
         'Inclusion mask, baseline period',
         'Inclusion mask, reporting period',
+
         # 'Temperature, baseline period',
         # 'Temperature, reporting period',
         # 'Temperature, normal year',
+
+        # 'Masked temperature, reporting period',
     ])
 
     for d in derivatives:


### PR DESCRIPTION
This PR adds 4 series to the eemeter: 

    'Masked baseline model minus observed, reporting period'
    'Masked baseline model, reporting period'
    'Masked observed, reporting period'
    'Masked temperature, reporting period'

These series will make it easier to verify proper masking and make it unnecessary to actually apply the mask.