### PR TITLE
Add __init__ to sample_data and *.csv to setup.py

### DIFF
--- a/eemeter/__init__.py
+++ b/eemeter/__init__.py
@@ -1,5 +1,5 @@
 # Version
-VERSION = (1, 2, 1)
+VERSION = (1, 2, 0)
 
 
 def get_version():

--- a/eemeter/__init__.py
+++ b/eemeter/__init__.py
@@ -1,5 +1,5 @@
 # Version
-VERSION = (1, 2, 0)
+VERSION = (1, 2, 1)
 
 
 def get_version():

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         'statsmodels >= 0.8.0rc1',
         'SQLAlchemy',
     ],
-    package_data={'': ['*.json', '*.gz']},
+    package_data={'': ['*.json', '*.gz', '*.csv']},
     setup_requires=['pytest-runner'],
     tests_require=['pytest'],
     entry_points={


### PR DESCRIPTION
Currently, when building the dist wheel, the sample_data folder is being ignored. Add __init__.py to sample_data folder and *.csv to setup.py package data so the next release picks it up. Also bumped the version number to 1.2.1.

closes #83