### PR TITLE
Some config enhancements for test suite and debugging/logging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,9 @@ install:
 
 before_script:
   # <CodeClimate>
-  - [ "$TRAVIS_PULL_REQUEST" == "false" ] && curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-  - [ "$TRAVIS_PULL_REQUEST" == "false" ] && chmod +x ./cc-test-reporter
-  - [ "$TRAVIS_PULL_REQUEST" == "false" ] && ./cc-test-reporter before-build
+  - '[ "$TRAVIS_PULL_REQUEST" == "false" ] && curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter'
+  - '[ "$TRAVIS_PULL_REQUEST" == "false" ] && chmod +x ./cc-test-reporter'
+  - '[ "$TRAVIS_PULL_REQUEST" == "false" ] && ./cc-test-reporter before-build'
   # </CodeClimate>
 
 script:
@@ -44,5 +44,5 @@ script:
 after_script:
   - coveralls
   # <CodeClimate>
-  - [ "$TRAVIS_PULL_REQUEST" == "false" ] && ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+  - '[ "$TRAVIS_PULL_REQUEST" == "false" ] && ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT'
   # </CodeClimate>

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
+env:
+  global:
+    # <CodeClimate>
+    # TODO(eemeter): Register on Code Climate, replace this with your CC_TEST_REPORTER_ID from https://docs.codeclimate.com/docs/travis-ci-test-coverage
+    - CC_TEST_REPORTER_ID=787a2f89b15c637323c7340d65ec17e898ac44480706b4b4122ea040c2a88f1d
+    # </CodeClimate>
+
 sudo: false
 
 cache:
@@ -24,8 +31,18 @@ install:
   - pip install tox-travis
   - pip install coveralls
 
+before_script:
+  # <CodeClimate>
+  - [ "$TRAVIS_PULL_REQUEST" == "false" ] && curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - [ "$TRAVIS_PULL_REQUEST" == "false" ] && chmod +x ./cc-test-reporter
+  - [ "$TRAVIS_PULL_REQUEST" == "false" ] && ./cc-test-reporter before-build
+  # </CodeClimate>
+
 script:
   - tox
 
 after_script:
   - coveralls
+  # <CodeClimate>
+  - [ "$TRAVIS_PULL_REQUEST" == "false" ] && ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+  # </CodeClimate>

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -4,6 +4,7 @@ mock==2.0.0
 nbsphinx==0.2.14
 pandoc==1.0.0b3
 pytest==3.2.3
+pytest-xdist==1.20.1
 pytest-flake8==0.8.1
 sphinx==1.6.4
 sphinx-rtd-theme==0.2.4

--- a/eemeter/cli.py
+++ b/eemeter/cli.py
@@ -3,12 +3,15 @@ import datetime
 import pytz
 import csv
 import json
+import logging
 import os
 import errno
 import click
 import pandas as pd
 from scipy import stats
 import numpy as np
+
+from eemeter.log import setup_logging
 from eemeter.structures import EnergyTrace
 from eemeter.io.serializers import ArbitraryStartSerializer
 from eemeter.ee.meter import EnergyEfficiencyMeter
@@ -17,9 +20,15 @@ from eemeter.processors.dispatchers import (
 )
 from eemeter.modeling.models.caltrack import CaltrackMonthlyModel
 
+logger = logging.getLogger(__name__)
+
 
 @click.group()
-def cli():
+@click.option('--log-config', help='override eemeter logging config file. accepts json files.')
+@click.option('--log-console', is_flag=True, default=False,
+              help="allow logging handlers named like 'console'")
+@click.option('--log-level', help='override eemeter logging level.')
+def cli(log_config, log_level, log_console):
     '''
        \b
        Example usage:
@@ -64,6 +73,10 @@ def cli():
        requirement, pass the option "--ignore-data-sufficiency".
 
     '''
+    if log_config:
+        setup_logging(log_config, eemeter_log_level=log_level, allow_console_logging=log_console)
+    else:
+        setup_logging(eemeter_log_level=log_level, allow_console_logging=log_console)
 
 
 def slugify(value):

--- a/eemeter/log/__init__.py
+++ b/eemeter/log/__init__.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+""" boilerplate to set up logging cleanly and avoid redundant setup (avoid unintended side-effects)
+
+note, this module is intentionally not called `logging`, as that can mask stdlib `logging` module.
+at least in certain contexts like PyCharm's test runner. leave it as `log` for best results.
+"""
+import json
+import logging
+import logging.config
+import os
+import sys
+import warnings
+
+
+HERE = os.path.abspath(os.path.dirname(__file__))
+
+EEMETER_LOGGER_NAME = 'eemeter'  # This needs to match the top package name.
+EEMETER_LOGGER_HAS_BEEN_SET_UP = False
+
+
+def setup_logging(
+        path_to_logging_json=os.path.join(HERE, "logging.json"),
+        eemeter_log_level=None,
+        allow_console_logging=True):
+    """ Setup logging configuration from file.
+
+    Parameters
+    ----------
+    path_to_logging_json : str
+        Optional path to custom logging configuration json file. passed to dictConfig()
+    eemeter_log_level : str
+        Optional override for eemeter logging level. (Cascades to eemeter.*)
+    allow_console_logging : bool
+        If not True, then all logging handlers with 'console' in the name will be disabled.
+    """
+    global EEMETER_LOGGER_HAS_BEEN_SET_UP  # global is evil in general, but this is OK.
+    our_logger = logging.getLogger(EEMETER_LOGGER_NAME)
+
+    with open(path_to_logging_json, 'r') as f:
+        config = json.load(f)
+
+    logging.config.dictConfig(config)
+
+    our_logger.debug('setting logging.captureWarnings(True)')
+    logging.captureWarnings(True)
+
+    if eemeter_log_level is not None:
+        try:
+            our_logger.setLevel(logging.getLevelName(eemeter_log_level.upper()))
+        except:
+            our_logger.error("could not set logging level to {!r}. "
+                         "please use a standard Python logging level.".format(eemeter_log_level))
+            raise
+
+    if not allow_console_logging:
+        for _logger in (our_logger, logging.getLogger('py.warnings')):
+            handlers = [h for h in _logger.handlers if not 'console' in h.get_name().lower()]
+            _logger.handlers = handlers
+
+    EEMETER_LOGGER_HAS_BEEN_SET_UP = True
+    return our_logger

--- a/eemeter/log/__init__.py
+++ b/eemeter/log/__init__.py
@@ -45,10 +45,10 @@ def setup_logging(
     if eemeter_log_level is not None:
         try:
             our_logger.setLevel(logging.getLevelName(eemeter_log_level.upper()))
-        except:
-            our_logger.error("could not set logging level to {!r}. "
-                             "please use a standard Python logging level.".format(
-                eemeter_log_level))
+        except ValueError:
+            our_logger.error(
+                    "could not set logging level to {!r}. "
+                    "please use a standard Python logging level.".format(eemeter_log_level))
             raise
 
     if not allow_console_logging:

--- a/eemeter/log/logging.json
+++ b/eemeter/log/logging.json
@@ -1,0 +1,77 @@
+{
+  "formatters": {
+    "simple": {
+      "format": "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    },
+    "verbose": {
+      "format": "%(levelname)-8s %(asctime)s %(name)s L%(lineno)s | %(funcName)s | %(message)s"
+    }
+  },
+  "handlers": {
+    "console": {
+      "class": "logging.StreamHandler",
+      "formatter": "verbose",
+      "level": "DEBUG",
+      "stream": "ext://sys.stderr"
+    },
+    "file_debug": {
+      "backupCount": 2,
+      "class": "logging.handlers.RotatingFileHandler",
+      "encoding": "utf8",
+      "filename": "/tmp/eemeter.debug.log",
+      "formatter": "verbose",
+      "level": "DEBUG",
+      "maxBytes": 10485760
+    },
+    "file_info": {
+      "backupCount": 2,
+      "class": "logging.handlers.RotatingFileHandler",
+      "encoding": "utf8",
+      "filename": "/tmp/eemeter.info.log",
+      "formatter": "simple",
+      "level": "INFO",
+      "maxBytes": 10485760
+    },
+    "file_error": {
+      "backupCount": 2,
+      "class": "logging.handlers.RotatingFileHandler",
+      "encoding": "utf8",
+      "filename": "/tmp/eemeter.error.log",
+      "formatter": "verbose",
+      "level": "ERROR",
+      "maxBytes": 10485760
+    }
+  },
+  "loggers": {
+    "eemeter": {
+      "handlers": [
+        "console",
+        "file_debug",
+        "file_info",
+        "file_error"
+      ],
+      "level": "INFO",
+      "propagate": false
+    },
+    "py.warnings": {
+      "handlers": [
+        "console",
+        "file_debug",
+        "file_info",
+        "file_error"
+      ],
+      "level": "INFO",
+      "propagate": false
+    }
+  },
+  "root": {
+    "handlers": [
+      "console",
+      "file_debug",
+      "file_info",
+      "file_error"
+    ],
+    "level": "INFO"
+  },
+  "version": 1
+}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,0 @@
-[pytest]
-norecursedirs = .* *.egg _build
-flake8-ignore =
-    docs/conf.py ALL
-    build/* ALL

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+""" py.test runs hooks etc. from conftest.py files. they apply recursively to test suites below.
+
+py.test docs: https://docs.pytest.org/en/2.7.3/plugins.html
+"""
+import logging
+from eemeter.log import setup_logging
+
+def pytest_runtest_setup(item):
+    setup_logging(eemeter_log_level=logging.DEBUG, allow_console_logging=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,8 @@
 
 py.test docs: https://docs.pytest.org/en/2.7.3/plugins.html
 """
-import logging
-from eemeter.log import setup_logging
+from eemeter.log import setup_logging, disable_file_logging
 
-def pytest_runtest_setup(item):
-    setup_logging(eemeter_log_level=logging.DEBUG, allow_console_logging=True)
+def pytest_configure():
+    setup_logging(eemeter_log_level='DEBUG', allow_console_logging=True)
+    disable_file_logging()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,9 @@
 """ py.test runs hooks etc. from conftest.py files. they apply recursively to test suites below.
 
-py.test docs: https://docs.pytest.org/en/2.7.3/plugins.html
+https://docs.pytest.org/en/3.2.3/writing_plugins.html?highlight=conftest
 """
 from eemeter.log import setup_logging, disable_file_logging
+
 
 def pytest_configure():
     setup_logging(eemeter_log_level='DEBUG', allow_console_logging=True)

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,14 @@
 [pytest]
+minversion = 3.0.0
 norecursedirs = .* *.egg _build
 flake8-ignore =
     docs/conf.py ALL
     build/* ALL
+addopts =
+    --showlocals
+    --ignore=setup.py
+    -n4
+;;; ^^^ -n sets number of parallel processes for pytest-xdist. if you have issues, set -n0 when calling.
 
 [tox]
 envlist = py{27,34,35,36},docs,flake8
@@ -14,6 +20,7 @@ deps =
     pytest
     coveralls
     pytest-cov
+    pytest-xdist
     codecov
     numpy
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,9 @@
+[pytest]
+norecursedirs = .* *.egg _build
+flake8-ignore =
+    docs/conf.py ALL
+    build/* ALL
+
 [tox]
 envlist = py{27,34,35,36},docs,flake8
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,9 @@ addopts =
     -n4
 ;;; ^^^ -n sets number of parallel processes for pytest-xdist. if you have issues, set -n0 when calling.
 
+[flake8]
+max-line-length = 100
+
 [tox]
 envlist = py{27,34,35,36},docs,flake8
 


### PR DESCRIPTION
👋 Hello! My first change here. It is not representative of my usual code style, as it is mostly 'dirty work' to get logging configs right and so on. I have aimed for clarity nonetheless but I'm happy to take any feedback and change the code style accordingly.

I made a few enhancements that came to mind while getting to know the codebase, via playing with your test suite and so on. Of course, these broken into discrete changes; for example I can take out the Travis CI CodeClimate thing if that doesn't make sense here. Let me know if you want me to break it up into smaller changes with `cherry-pick` and I am happy to do so 😄 

Rundown:

* Add test suite config to use `pytest-xdist` to parallelize across up to 4 cores, speeding up test suite by a bit better than 2x. [More notes in commit logs.](https://github.com/hangtwenty/eemeter/commit/6d574da726c3f383d028b8bb51abbc518afc3a7d)

* [Add tooling for logging configuration when using the CLI.](https://github.com/hangtwenty/eemeter/commit/6d574da726c3f383d028b8bb51abbc518afc3a7d) Allows changing the whole logging config, but more typically you would let the default config get used... and optionally `--log-console` to turn on console log output, and/or `--log-level=DEBUG` to increase the verbosity. For the console logger and the `DEBUG` level logger, the default logging config's log format has a "debug trace" flavor to it, showing modules, function names, and line numbers. (Reusing my favorite base config from other projects.) I'll paste some example logs in the thread.

* During test suite, set to max verbosity and logs on console. This just results in more info when you want it. You won't see extra output except when tests fail.

* During test suite, disable file logging.

* Travis CI: add CodeClimate integration boilerplate. (Won't be relevant until setting up your upstream repository with CodeClimate, but that's easy, and I can help!)

* Consolidate `pytest.ini` and `tox.ini`, [rationale in commit log](https://github.com/hangtwenty/eemeter/commit/429a05b11dda0475d9755849f5c58fcd9d9c2c23)

* set flake8 config to line lengths of 100, [rationale in this commit message](https://github.com/hangtwenty/eemeter/commit/413599bf0cd32459f983ba612313eaf5905b7963)