### PR TITLE
Add static security analysis with openstack/bandit, and address initial findings

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,5 +1,6 @@
 ipykernel==4.6.1
 lxml==4.0.0
+defusedxml==0.5.0
 mock==2.0.0
 nbsphinx==0.2.14
 pandoc==1.0.0b3

--- a/eemeter/io/parsers.py
+++ b/eemeter/io/parsers.py
@@ -1,9 +1,14 @@
 from collections import defaultdict
 from datetime import datetime, timedelta
-from lxml import etree
 import pytz
 import six
 import warnings
+
+from defusedxml.lxml import (
+    fromstring as etree_fromstring,
+    parse as etree_parse,
+    tostring as etree_tostring
+)
 
 from eemeter.structures import EnergyTrace
 from eemeter.io.serializers import ArbitrarySerializer
@@ -459,10 +464,10 @@ class ESPIUsageParser(object):
 
     def __init__(self, xml):
         try:
-            self.root = etree.parse(xml)  # xml is file path or file object
+            self.root = etree_parse(xml)  # xml is file path or file object
         except IOError:
             if isinstance(xml, six.string_types + (six.binary_type,)):
-                self.root = etree.fromstring(xml)  # xml is a string.
+                self.root = etree_fromstring(xml)  # xml is a string.
         self.timezone = self._get_timezone()
 
     def has_solar(self):
@@ -706,7 +711,7 @@ class ESPIUsageParser(object):
                     message = (
                         "Could not find the ReadingType for the IntervalBlock"
                         " element {} using the MeterReading ID {}."
-                        .format(etree.tostring(entry), meter_reading_id)
+                        .format(etree_tostring(entry), meter_reading_id)
                     )
                     warnings.warn(message)
 

--- a/eemeter/weather/clients.py
+++ b/eemeter/weather/clients.py
@@ -1,4 +1,10 @@
-import ftplib
+""" Various clients for getting public weather data over the public Internet.
+
+TODO: consider authentication of who's on other end of these URLs.
+This would be to protect against MITM as well as DNS level attacks like DNS spoofing.
+(Not covered by DNS alone, nor HTTP nor FTP. DNSSEC could help but is not widespread yet).
+"""
+import ftplib  # nosec
 import gzip
 from io import BytesIO
 import json
@@ -22,9 +28,15 @@ class NOAAClient(object):
         self.station_index = None  # lazily load
 
     def _get_ftp_connection(self):
+        """
+        Security note: `bandit` would (appropriately) flag these FTP usages as a *potential*
+        security issue. Namely this is an issue for private data transmitted over FTP (plaintext).
+        However we have to accept this flaw because (a) NOAA doesn't have FTPS nor SFTP, and
+        (b) the information in this case is safe to transmit in plaintext (not private at all).
+        """
         for _ in range(self.n_tries):
             try:
-                ftp = ftplib.FTP("ftp.ncdc.noaa.gov")
+                ftp = ftplib.FTP("ftp.ncdc.noaa.gov")  # nosec
             except ftplib.all_errors as e:
                 logger.warn("FTP connection issue: %s", e)
             else:

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         'dateparser',
         'holidays',
         'lxml',
+        'defusedxml',
         'numpy >= 1.10.2',
         'scipy',
         'pandas >= 0.19.2',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35,36},docs,flake8
+envlist = py{27,34,35,36},docs,flake8,security-baseline
 
 [testenv]
 passenv = CI TRAVIS TRAVIS_*
@@ -36,9 +36,27 @@ deps =
 commands =
     flake8 eemeter --max-line-length=120
 
+[testenv:security-baseline]
+; For 'security baseline testing' locally, show only >=MEDIUM severity.
+; bandit's arguments for Severity filters: -l for LOW, -ll for MEDIUM, -lll for HIGH
+deps =
+    bandit
+commands =
+    bandit -ll -r eemeter
+
+[testenv:security-gatekeep]
+; For gatekeeping (i.e. actually failing the Travis CI), >=MEDIUM confidence, HIGH severity
+; bandit's arguments for Severity filters: -l for LOW, -ll for MEDIUM, -lll for HIGH
+; bandit's arguments for Confidence filters: -i for LOW, -ii for MEDIUM, -iii for HIGH
+deps =
+    bandit
+commands =
+    bandit -lll -ii -r eemeter
+
 [travis]
 python =
     2.7: py27
     3.4: py34
     3.5: py35, docs, flake8
     3.6: py36
+    security-gatekeep: security-gatekeep


### PR DESCRIPTION
## 🕵️  Add 'bandit' security static analysis to tox & Travis  (71e065e)

Documented with some comments in tox.ini, which should explain I hope!

The official bandit docs are good too.

https://github.com/openstack/bandit

I separated into a 'baseline testing' that is stricter, but more actionable as it can run locally; and 'gatekeeping' that only fails-out on HIGH severity, and that part runs in Travis to put the breaks on and
have us fix or mitigate the issue before merge.

## 🔒 Swap lxml -> defusedxml to fix a security finding (97ed091)

Bandit reported:

    --------------------------------------------------
    >> Issue: [B320:blacklist] Using lxml.etree.parse to parse untrusted XML data is known to be vulnerable to XML attacks. Replace lxml.etree.parse with its defusedxml equivalent function.
       Severity: Medium   Confidence: High
       Location: eemeter/io/parsers.py:462
    461	        try:
    462	            self.root = etree.parse(xml)  # xml is file path or file object
    463	        except IOError:

    --------------------------------------------------
    >> Issue: [B320:blacklist] Using lxml.etree.fromstring to parse untrusted XML data is known to be vulnerable to XML attacks. Replace lxml.etree.fromstring with its defusedxml equivalent function.
       Severity: Medium   Confidence: High
       Location: eemeter/io/parsers.py:465
    464	            if isinstance(xml, six.string_types + (six.binary_type,)):
    465	                self.root = etree.fromstring(xml)  # xml is a string.
    466	        self.timezone = self._get_timezone()

----

Happily the fix is easy. We just swap with the wrapper library, `defusedxml`. For more info:

* https://pypi.python.org/pypi/defusedxml
* http://lxml.de/FAQ.html#how-do-i-use-lxml-safely-as-a-web-service-endpoint

ℹ️ Note that it doesn't seem like a likely attack vector for the CLI,
and may not even be an attack vector in eemeter's SaaS offering.

However becuase it's straightforward to change it, seems worth doing.

---------------------------------------------------------

## 🤷‍♂️  Just _accept_ bandit's security scan finding re: FTP (no mitigation available without a complex change) (2d9cb98)

In short we just do not have another option for now. Added some notes about doing some authentication of these endpoints later on.