### PR TITLE
Additional logging improvements

### DIFF
--- a/eemeter/__init__.py
+++ b/eemeter/__init__.py
@@ -1,3 +1,7 @@
+import logging
+
+logging.getLogger(__name__).addHandler(logging.NullHandler())
+
 # Version
 VERSION = (1, 3, 2)
 

--- a/eemeter/cli.py
+++ b/eemeter/cli.py
@@ -1,14 +1,17 @@
 from collections import OrderedDict
-import datetime
-import pytz
 import csv
-import json
-import os
+import datetime
 import errno
+import json
+import logging
+import os
+
 import click
+import pytz
 import pandas as pd
 from scipy import stats
 import numpy as np
+
 from eemeter.structures import EnergyTrace
 from eemeter.io.serializers import ArbitraryStartSerializer
 from eemeter.ee.meter import EnergyEfficiencyMeter
@@ -16,6 +19,9 @@ from eemeter.processors.dispatchers import (
     get_approximate_frequency,
 )
 from eemeter.modeling.models.caltrack import CaltrackMonthlyModel
+
+
+logging.basicConfig()
 
 
 @click.group()


### PR DESCRIPTION
This PR adds a NullHandler to the `__init__.py` to avoid the `'No handlers could be found for logger XXX'` message which shows up if no handlers are configured.

It also adds a basic logging config to the CLI.