### PR TITLE
Add CaltrackDailyModel in class_name_map 

### DIFF
--- a/eemeter/ee/meter.py
+++ b/eemeter/ee/meter.py
@@ -291,7 +291,7 @@ class EnergyEfficiencyMeter(object):
                 if isinstance(custom_model_class, string_types):
                     class_name_map = {
                         f.__name__: f
-                        for f in [CaltrackMonthlyModel, HourlyDayOfWeekModel]
+                        for f in [CaltrackMonthlyModel, CaltrackDailyModel, HourlyDayOfWeekModel]
                     }
                     ModelClass = class_name_map[custom_model_class]
                 else:


### PR DESCRIPTION
Fixing following error found while running CaltrackDailyModel

Traceback (most recent call last):
  File "/app/.heroku/python/lib/python3.6/site-packages/celery/app/trace.py", line 374, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/app/metering/tasks/trigger_meter.py", line 55, in trigger_meter
    meter_input, model=model, formatter=formatter)
  File "/app/.heroku/python/lib/python3.6/site-packages/eemeter/ee/meter.py", line 498, in evaluate
    ModelClass, model_kwargs = self._get_model(model, selector)
  File "/app/.heroku/python/lib/python3.6/site-packages/eemeter/ee/meter.py", line 296, in _get_model
    ModelClass = class_name_map[custom_model_class]
KeyError: 'CaltrackDailyModel'
 98%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▎  | 981/1000 [08:22<00:09,  1.95it/s]2018-01-31 23:38:18,871 ERROR [eemeter.processors.dispatch