### PR TITLE
Error checking when there is read error for a region and year weather data

### DIFF
--- a/eemeter/co2/avert.py
+++ b/eemeter/co2/avert.py
@@ -20,8 +20,9 @@ class AVERTSource(object):
         if not self.co2_store.key_exists(self.year, self.region):
             co2_by_load, load_by_hour = self.client.read_rdf_file(
                 self.year, self.region)
-            self.co2_store.save_json(self.year, self.region,
-                                     co2_by_load, load_by_hour)
+            if len(co2_by_load) > 0 and len(load_by_hour) > 0:
+                self.co2_store.save_json(self.year, self.region,
+                                         co2_by_load, load_by_hour)
 
     def get_co2_by_load(self):
         return self.co2_store.retrieve_co2_by_load(self.year, self.region)

--- a/eemeter/co2/clients.py
+++ b/eemeter/co2/clients.py
@@ -68,6 +68,9 @@ class AVERTClient(object):
         else:
             streamdata = self._retrieve_from_zipfile(year, region)
 
+        if not streamdata:
+            # return empty series
+            return pd.Series(), pd.Series()
         # Open the workbook
         wb = xlrd.open_workbook(file_contents=streamdata)
 

--- a/eemeter/co2/clients.py
+++ b/eemeter/co2/clients.py
@@ -70,6 +70,8 @@ class AVERTClient(object):
 
         if not streamdata:
             # return empty series
+            logging.info("Could not fine weather data for Year: " +
+                         year + " and Region " + region)
             return pd.Series(), pd.Series()
         # Open the workbook
         wb = xlrd.open_workbook(file_contents=streamdata)


### PR DESCRIPTION
eemeter throwing following exception on weather data could not be read


2018-02-11 18:15:57,727 ERROR [celery.app.trace:248] Task metering.tasks.trigger_meter.trigger_meter[cf260681-3664-4932-a955-d83824467802] raised unexpected: TypeError('expected str, bytes or os.PathLike object, not NoneType',)
Traceback (most recent call last):
  File "/app/.heroku/python/lib/python3.6/site-packages/celery/app/trace.py", line 374, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/app/metering/tasks/trigger_meter.py", line 55, in trigger_meter
    meter_input, model=model, formatter=formatter)
  File "/app/.heroku/python/lib/python3.6/site-packages/eemeter/ee/meter.py", line 551, in evaluate
    site, derivative_freq=derivative_freq)
  File "/app/.heroku/python/lib/python3.6/site-packages/eemeter/ee/derivatives.py", line 36, in unpack
    co2_source = get_co2_source(site)
  File "/app/.heroku/python/lib/python3.6/site-packages/eemeter/processors/location.py", line 154, in get_co2_source
    avert_source = AVERTSource(use_year, region)
  File "/app/.heroku/python/lib/python3.6/site-packages/eemeter/co2/avert.py", line 17, in __init__
    self._check_for_data()
  File "/app/.heroku/python/lib/python3.6/site-packages/eemeter/co2/avert.py", line 22, in _check_for_data
    self.year, self.region)
  File "/app/.heroku/python/lib/python3.6/site-packages/eemeter/co2/clients.py", line 72, in read_rdf_file
    wb = xlrd.open_workbook(file_contents=streamdata)
  File "/app/.heroku/python/lib/python3.6/site-packages/xlrd/__init__.py", line 116, in open_workbook
    with open(filename, "rb") as f:
TypeError: expected str, bytes or os.PathLike object, not NoneType
