### PR TITLE
Changed log message from info to error and added str typecasting

### DIFF
--- a/eemeter/co2/clients.py
+++ b/eemeter/co2/clients.py
@@ -70,8 +70,8 @@ class AVERTClient(object):
 
         if not streamdata:
             # return empty series
-            logging.info("Could not fine weather data for Year: " +
-                         year + " and Region " + region)
+            logging.error("Could not find weather data for Year: " +
+                         str(year) + " and Region " + str(region))
             return pd.Series(), pd.Series()
         # Open the workbook
         wb = xlrd.open_workbook(file_contents=streamdata)


### PR DESCRIPTION
Handling weather data read error. I am just logging here but should we throw our own exception ?

2018-02-13T16:07:41.315432+00:00 app[worker.1]: Traceback (most recent call last):
2018-02-13T16:07:41.315434+00:00 app[worker.1]:   File "/app/.heroku/python/lib/python3.6/site-packages/celery/app/trace.py", line 374, in trace_task
2018-02-13T16:07:41.315436+00:00 app[worker.1]:     R = retval = fun(*args, **kwargs)
2018-02-13T16:07:41.315438+00:00 app[worker.1]:   File "/app/.heroku/python/lib/python3.6/site-packages/celery/app/trace.py", line 629, in __protected_call__
2018-02-13T16:07:41.315439+00:00 app[worker.1]:     return self.run(*args, **kwargs)
2018-02-13T16:07:41.315441+00:00 app[worker.1]:   File "/app/metering/tasks/trigger_meter.py", line 55, in trigger_meter
2018-02-13T16:07:41.315443+00:00 app[worker.1]:     meter_input, model=model, formatter=formatter)
2018-02-13T16:07:41.315444+00:00 app[worker.1]:   File "/app/.heroku/python/lib/python3.6/site-packages/eemeter/ee/meter.py", line 551, in evaluate
2018-02-13T16:07:41.315446+00:00 app[worker.1]:     site, derivative_freq=derivative_freq)
2018-02-13T16:07:41.315448+00:00 app[worker.1]:   File "/app/.heroku/python/lib/python3.6/site-packages/eemeter/ee/derivatives.py", line 36, in unpack
2018-02-13T16:07:41.315449+00:00 app[worker.1]:     co2_source = get_co2_source(site)
2018-02-13T16:07:41.315450+00:00 app[worker.1]:   File "/app/.heroku/python/lib/python3.6/site-packages/eemeter/processors/location.py", line 154, in get_co2_source
2018-02-13T16:07:41.315452+00:00 app[worker.1]:     avert_source = AVERTSource(use_year, region)
2018-02-13T16:07:41.315453+00:00 app[worker.1]:   File "/app/.heroku/python/lib/python3.6/site-packages/eemeter/co2/avert.py", line 17, in __init__
2018-02-13T16:07:41.315455+00:00 app[worker.1]:     self._check_for_data()
2018-02-13T16:07:41.315456+00:00 app[worker.1]:   File "/app/.heroku/python/lib/python3.6/site-packages/eemeter/co2/avert.py", line 22, in _check_for_data
2018-02-13T16:07:41.315458+00:00 app[worker.1]:     self.year, self.region)
2018-02-13T16:07:41.315459+00:00 app[worker.1]:   File "/app/.heroku/python/lib/python3.6/site-packages/eemeter/co2/clients.py", line 72, in read_rdf_file
2018-02-13T16:07:41.315460+00:00 app[worker.1]:     wb = xlrd.open_workbook(file_contents=streamdata)
2018-02-13T16:07:41.315462+00:00 app[worker.1]:   File "/app/.heroku/python/lib/python3.6/site-packages/xlrd/__init__.py", line 116, in open_workbook
2018-02-13T16:07:41.315463+00:00 app[worker.1]:     with open(filename, "rb") as f:
2018-02-13T16:07:41.315469+00:00 app[worker.1]: TypeError: expected str, bytes or os.PathLike object, not NoneType

