### PR TITLE
Bugfix/hourly model df order

### DIFF
--- a/eemeter/modeling/models/hourly_model.py
+++ b/eemeter/modeling/models/hourly_model.py
@@ -226,7 +226,7 @@ class HourlyDayOfWeekModel(object):
 
         # A series DS
         prediction = pd.concat([weekday_pred, weekend_pred])
-        prediction.sort_index()
+        prediction.sort_index(inplace=True)
 
         # A Series DS
         variance = self.compute_variance(test_df)

--- a/eemeter/modeling/models/hourly_model.py
+++ b/eemeter/modeling/models/hourly_model.py
@@ -194,7 +194,7 @@ class HourlyDayOfWeekModel(object):
         weekday_var = pd.Series(weekday_var, index=weekday_df.index)
 
         variance_df = pd.concat([weekday_var, weekend_var])
-        variance_df.sort_index()
+        variance_df.sort_index(inplace=True)
         return variance_df
 
     def predict(self, df, summed=True):


### PR DESCRIPTION
@philngo, I am a user of openeemeter. I had an issue where derivatives being returned from `HourlyDayOfWeekModel` were out of order. Appears to be related to a sorting operation after concatenating, which wasn't being done inplace but rather on an unused copy. Works properly on my own local copy with this change. Please advise if there are tests I should run to verify. Thank you. 