### PR TITLE
Calculate fractional savings uncertainty and OLS error bands 

### DIFF
--- a/eemeter/api.py
+++ b/eemeter/api.py
@@ -242,10 +242,16 @@ class ModelResults(object):
 
     settings : :any:`dict`
         A dictionary of settings used by the method.
-    metrics : :any:`ModelMetrics`
+    totals_metrics : :any:`ModelMetrics`
         A ModelMetrics object, if one is calculated and associated with this
         model. (This initializes to None.) The ModelMetrics object contains
-        model fit information and descriptive statistics about the underlying data.
+        model fit information and descriptive statistics about the underlying data,
+        with that data expressed as period totals.
+    avgs_metrics : :any:`ModelMetrics`
+        A ModelMetrics object, if one is calculated and associated with this
+        model. (This initializes to None.) The ModelMetrics object contains
+        model fit information and descriptive statistics about the underlying data,
+        with that data expressed as daily averages.
     '''
 
     def __init__(
@@ -273,7 +279,8 @@ class ModelResults(object):
             settings = {}
         self.settings = settings
 
-        self.metrics = None
+        self.totals_metrics = None
+        self.avgs_metrics = None
 
     def __repr__(self):
         return (
@@ -295,11 +302,16 @@ class ModelResults(object):
             'warnings': [w.json() for w in self.warnings],
             'metadata': self.metadata,
             'settings': self.settings,
-            'metrics': None
+            'totals_metrics': None,
+            'avgs_metrics': None
         }
-        if self.metrics:
-            data['metrics'] = [
-                self.metrics.json()
+        if self.totals_metrics:
+            data['totals_metrics'] = [
+                self.totals_metrics.json()
+            ]
+        if self.avgs_metrics:
+            data['avgs_metrics'] = [
+                self.avgs_metrics.json()
             ]
         if with_candidates:
             data['candidates'] = [

--- a/eemeter/caltrack.py
+++ b/eemeter/caltrack.py
@@ -122,6 +122,11 @@ def _caltrack_predict_design_matrix(
 
     if isinstance(data.index, pd.DatetimeIndex):
         days_per_period = day_counts(zeros)
+    else:
+        try:
+            days_per_period = data['n_days']
+        except KeyError:
+            raise KeyError('Data needs DatetimeIndex or an n_days column.')
 
     # TODO(philngo): handle different degree day methods and hourly temperatures
     if model_type in ['intercept_only', 'hdd_only', 'cdd_only', 'cdd_hdd']:
@@ -131,8 +136,6 @@ def _caltrack_predict_design_matrix(
             base_load = intercept * days_per_period
         else:
             base_load = intercept * ones
-        # The last row of data was nan -- Restore the NaN
-        base_load[-1] = np.nan
     elif model_type is None:
         raise ValueError('Model not valid for prediction: model_type=None')
     else:
@@ -175,6 +178,17 @@ def _caltrack_predict_design_matrix(
             cooling_load = cdd * beta_cdd / days_per_period
     else:
         cooling_load = zeros
+
+    # If any of the rows of input data contained NaNs, restore the NaNs
+    # Note: If data contains ANY NaNs at all, this declares the entire row a NaN.
+    # TODO(philngo): Consider making this more nuanced.
+    def _restore_nans(load):
+        load = load[data.sum(axis=1, skipna=False).notnull()].reindex(data.index)
+        return load
+
+    base_load = _restore_nans(base_load)
+    heating_load = _restore_nans(heating_load)
+    cooling_load = _restore_nans(cooling_load)
 
     if disaggregated:
         return pd.DataFrame({
@@ -1071,7 +1085,8 @@ def caltrack_method(
         A DataFrame containing at least the column ``meter_value`` and 1 to n
         columns each of the form ``hdd_<heating_balance_point>``
         and ``cdd_<cooling_balance_point>``. DataFrames of this form can be
-        made using the :any:`eemeter.merge_temperature_data` method.
+        made using the :any:`eemeter.merge_temperature_data` method. Should
+        have a :any:`pandas.DatetimeIndex`.
     fit_cdd : :any:`bool`, optional
         If True, fit CDD models unless overridden by ``fit_cdd_only`` or
         ``fit_cdd_hdd`` flags. Should be set to ``False`` for gas meter data.
@@ -1214,14 +1229,26 @@ def caltrack_method(
         else:
             num_parameters = 0
 
-        predicted = _caltrack_predict_design_matrix(
+        predicted_avgs = _caltrack_predict_design_matrix(
             best_candidate.model_type,
             best_candidate.model_params,
             data,
             input_averages = True,
             output_averages = True,
         )
-        model_result.metrics = ModelMetrics(data.meter_value, predicted, num_parameters)
+        model_result.avgs_metrics = ModelMetrics(data.meter_value, predicted_avgs, num_parameters)
+
+        predicted_totals = _caltrack_predict_design_matrix(
+            best_candidate.model_type,
+            best_candidate.model_params,
+            data,
+            input_averages = True,
+            output_averages = False,
+        )
+
+        days_per_period = day_counts(data)
+        data_totals = data.meter_value*days_per_period
+        model_result.totals_metrics = ModelMetrics(data_totals, predicted_totals, num_parameters)
 
     return model_result
 
@@ -1473,21 +1500,59 @@ def caltrack_sufficiency_criteria(
         }
     )
 
+def _compute_ols_error(
+    t_stat, rmse_base_residuals, post_obs, base_obs, base_avg, post_avg, base_var, nprime
+):
+    ols_model_agg_error = ((t_stat * rmse_base_residuals * post_obs)
+        / (base_obs ** 0.5) * (1 + ((base_avg - post_avg) ** 2 / base_var)) ** 0.5)
+
+    ols_noise_agg_error = (t_stat * rmse_base_residuals
+        * (post_obs * base_obs / nprime) ** 0.5)
+
+    ols_total_agg_error = (ols_model_agg_error ** 2 + ols_noise_agg_error ** 2) ** 0.5
+
+    return ols_total_agg_error, ols_model_agg_error, ols_noise_agg_error
+
+def _compute_fsu_error(
+    t_stat, frequency, post_obs, total_base_energy, rmse_base_residuals, base_avg, base_obs,
+    nprime
+):
+    if frequency == "billing":
+        a_coeff = -0.00022
+        b_coeff = 0.03306
+        c_coeff = 0.94054
+        months_reporting = post_obs
+    else:
+        a_coeff = -0.00024
+        b_coeff = 0.03535
+        c_coeff = 1.00286
+        months_reporting = post_obs / 30
+
+    fsu_error_band = (total_base_energy
+        * (t_stat * (a_coeff * months_reporting ** 2 + b_coeff * months_reporting + c_coeff) 
+        * (rmse_base_residuals / base_avg)
+        * ((base_obs / nprime) * (1 + (2 / nprime)) * (1 / post_obs)) ** 0.5))
+
+    return fsu_error_band
 
 def caltrack_metered_savings(
-    baseline_model, reporting_meter_data, temperature_data,
-    degree_day_method='daily', with_disaggregated=False,
+    model_results, reporting_meter_data, temperature_data,
+    degree_day_method='daily', with_disaggregated=False, frequency='unknown',
+    t_stat=1.649
 ):
     ''' Compute metered savings, i.e., savings in which the baseline model
     is used to calculate the modeled usage in the reporting period. This
     modeled usage is then compared to the actual usage from the reporting period.
+    Also compute two measures of the uncertainty of the aggregate savings estimate,
+    a fractional savings uncertainty (FSU) error band and an OLS error band. (To convert
+    the FSU error band into FSU, divide by total estimated savings.)
 
     Parameters
     ----------
-    baseline_model : :any:`eemeter.CandidateModel`
-        Model to use for predicting pre-intervention usage.
+    model_results : :any:`eemeter.ModelResults`
+        ModelResult object to use for predicting pre-intervention usage.
     reporting_meter_data : :any:`pandas.DataFrame`
-        The observed reporting period data. Savings will be computed for the
+        The observed reporting period data (totals). Savings will be computed for the
         periods supplied in the reporting period data.
     temperature_data : :any:`pandas.Series`
         Hourly-frequency timeseries of temperature data during the reporting
@@ -1499,6 +1564,15 @@ def caltrack_metered_savings(
         If True, calculate baseline counterfactual disaggregated usage
         estimates. Savings cannot be disaggregated for metered savings. For
         that, use :any:`eemeter.caltrack_modeled_savings`.
+    frequency : :any`str`, optional
+        The frequency used for calculating the FSU error band. Frequency can be
+        ``'billing'`` or ``'daily'``. If frequency is anything else, the FSU and OLS
+        error bands will not be calculated.
+    t_stat : :any`float`
+        The t-statistic associated with the desired confidence level and degrees of
+        freedom (number of baseline observations minus the number of parameters).
+        Defaults to 1.649, the t-statistic associated with 363 degrees of freedom (365
+        observations minus two parameters) and a two-tailed 90% confidence level.
 
     Returns
     -------
@@ -1517,12 +1591,15 @@ def caltrack_metered_savings(
         - ``counterfactual_heating_load``
         - ``counterfactual_cooling_load``
 
+    error_bands : :any:`dict`, optional
+        If frequency is 'daily' or 'billing', will also return a dictionary of FSU and
+        OLS error bands for the aggregated energy savings over the post period.
     '''
     prediction_index = reporting_meter_data.index
-    predicted_baseline_usage = baseline_model.predict(
+    predicted_baseline_usage = model_results.model.predict(
         temperature_data, prediction_index, degree_day_method,
-        with_disaggregated=True
-    )
+        with_disaggregated=True)
+
     # CalTrack 3.5.1
     counterfactual_usage = predicted_baseline_usage['predicted_usage']\
         .to_frame('counterfactual_usage')
@@ -1546,7 +1623,45 @@ def caltrack_metered_savings(
         })
         results = results.join(counterfactual_usage_disaggregated)
 
-    return results.dropna().reindex(results.index)
+    error_bands = None
+
+    if frequency == 'daily' or frequency == 'billing':
+        num_parameters = model_results.totals_metrics.num_parameters
+
+        base_obs = model_results.totals_metrics.observed_length
+        post_obs = results['reporting_observed'].dropna().shape[0]
+
+        rmse_base_residuals = model_results.totals_metrics.rmse_adj
+        autocorr_resid = model_results.totals_metrics.autocorr_resid
+
+        base_avg = model_results.totals_metrics.observed_mean
+        post_avg = results['reporting_observed'].mean()
+        post_prediction_avg = results['counterfactual_usage'].mean()
+
+        base_var = model_results.totals_metrics.observed_variance
+
+        nprime = base_obs * (1 - autocorr_resid) / (1 + autocorr_resid)
+
+        total_base_energy = base_avg * base_obs
+
+        ols_total_agg_error, ols_model_agg_error, ols_noise_agg_error =_compute_ols_error(
+            t_stat, rmse_base_residuals, post_obs, base_obs, base_avg, post_avg, base_var,
+            nprime
+        )
+
+        fsu_error_band = _compute_fsu_error(
+            t_stat, frequency, post_obs, total_base_energy, rmse_base_residuals, base_avg,
+            base_obs, nprime
+        )
+
+        error_bands = {
+            "FSU Error Band": fsu_error_band,
+            "OLS Error Band": ols_total_agg_error,
+            "OLS Error Band: Model Error": ols_model_agg_error,
+            "OLS Error Band: Noise": ols_noise_agg_error
+        }
+
+    return results.dropna().reindex(results.index), error_bands
 
 
 def caltrack_modeled_savings(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -163,7 +163,8 @@ def test_model_results_minimal():
     assert model_results.json() == {
         'metadata': {},
         'method_name': 'method_name',
-        'metrics': None,
+        'totals_metrics': None,
+        'avgs_metrics': None,
         'model': None,
         'settings': {},
         'status': 'status',
@@ -201,7 +202,8 @@ def test_model_results_json_with_objects():
         }],
         'metadata': {},
         'method_name': 'method_name',
-        'metrics': None,
+        'totals_metrics': None,
+        'avgs_metrics': None,
         'model': {
             'formula': 'formula',
             'model_params': {},

--- a/tests/test_caltrack.py
+++ b/tests/test_caltrack.py
@@ -438,7 +438,6 @@ def test_caltrack_predict_design_matrix_input_avg_false_output_avg_true(
          input_averages = False,
          output_averages = True
     )
-    print(prediction)
     assert round(prediction.mean(), 3) == 28.253
 
 
@@ -457,7 +456,6 @@ def test_caltrack_predict_design_matrix_input_avg_false_output_avg_false(
          input_averages = False,
          output_averages = False
     )
-    print(prediction)
     assert round(prediction.mean(), 3) == 855.832
 
 
@@ -489,7 +487,6 @@ def test_caltrack_predict_design_matrix_input_avg_true_output_avg_false(
          input_averages = True,
          output_averages = False
     )
-    print(prediction)
     assert round(prediction.mean(), 3) == 855.832
 
 
@@ -508,9 +505,30 @@ def test_caltrack_predict_design_matrix_input_avg_true_output_avg_true(
          input_averages = True,
          output_averages = True
     )
-    print(prediction)
     assert round(prediction.mean(), 3) == 28.253
 
+
+
+def test_caltrack_predict_design_matrix_n_days(
+    cdd_hdd_h53_c68_billing_monthly_totals
+):
+    # This makes sure that the method works with n_days when
+    # DatetimeIndexes are not available.
+    data = cdd_hdd_h53_c68_billing_monthly_totals
+    data.reset_index()
+    data['n_days'] = 1
+    prediction = _caltrack_predict_design_matrix(
+         'cdd_hdd',
+         {'intercept': 13.420093629452852,
+         'beta_cdd': 2.257868665412409,
+         'beta_hdd': 1.0479347638717025,
+         'cooling_balance_point': 67,
+         'heating_balance_point': 54},
+         data,
+         input_averages = True,
+         output_averages = True
+    )
+    assert prediction.mean() is not None
 
 def test_get_too_few_non_zero_degree_day_warning_ok():
     warnings = get_too_few_non_zero_degree_day_warning(
@@ -1267,11 +1285,17 @@ def test_caltrack_method_num_parameters_equals_zero():
         'meter_value': [6, 1, 1, 6],
         'cdd_65': [5, 0, 0.1, 0],
         'hdd_65': [0, 0.1, 0.1, 5],
-    })
+        'start': pd.date_range(
+            start='2016-01-02', periods=4, freq='D', tz='UTC'),
+    }).set_index('start')
+
     model_results = caltrack_method(
         data, fit_intercept_only=True
     )
-    assert model_results.metrics.cvrmse == model_results.metrics.cvrmse_adj
+    assert model_results.totals_metrics.num_parameters == model_results.totals_metrics.num_parameters
+    assert model_results.avgs_metrics.num_parameters == model_results.avgs_metrics.num_parameters
+    assert model_results.totals_metrics.cvrmse == model_results.totals_metrics.cvrmse_adj
+    assert model_results.avgs_metrics.cvrmse == model_results.avgs_metrics.cvrmse_adj
 
 
 def test_caltrack_method_no_model():
@@ -1628,6 +1652,12 @@ def baseline_model(cdd_hdd_h60_c65):
 
 
 @pytest.fixture
+def baseline_model_results(cdd_hdd_h60_c65):
+    model_results = caltrack_method(cdd_hdd_h60_c65)
+    return model_results
+
+
+@pytest.fixture
 def reporting_model(cdd_hdd_h60_c65):
     model_results = caltrack_method(cdd_hdd_h60_c65)
     return model_results.model
@@ -1646,12 +1676,12 @@ def reporting_temperature_data():
 
 
 def test_caltrack_metered_savings_cdd_hdd(
-    baseline_model, reporting_meter_data, reporting_temperature_data
+    baseline_model_results, reporting_meter_data, reporting_temperature_data
 ):
 
-    results = caltrack_metered_savings(
-        baseline_model, reporting_meter_data, reporting_temperature_data,
-        degree_day_method='daily'
+    results, error_bands = caltrack_metered_savings(
+        baseline_model_results, reporting_meter_data, reporting_temperature_data,
+        degree_day_method='daily', frequency='daily', t_stat=1.649
     )
     assert list(results.columns) == [
         'reporting_observed', 'counterfactual_usage', 'metered_savings'
@@ -1660,12 +1690,12 @@ def test_caltrack_metered_savings_cdd_hdd(
 
 
 def test_caltrack_metered_savings_cdd_hdd_hourly_degree_days(
-    baseline_model, reporting_meter_data, reporting_temperature_data
+    baseline_model_results, reporting_meter_data, reporting_temperature_data
 ):
 
-    results = caltrack_metered_savings(
-        baseline_model, reporting_meter_data, reporting_temperature_data,
-        degree_day_method='hourly'
+    results , error_bands = caltrack_metered_savings(
+        baseline_model_results, reporting_meter_data, reporting_temperature_data,
+        degree_day_method='hourly', frequency='daily', t_stat=1.649
     )
     assert list(results.columns) == [
         'reporting_observed', 'counterfactual_usage', 'metered_savings'
@@ -1674,23 +1704,23 @@ def test_caltrack_metered_savings_cdd_hdd_hourly_degree_days(
 
 
 def test_caltrack_metered_savings_cdd_hdd_no_params(
-    baseline_model, reporting_meter_data, reporting_temperature_data
+    baseline_model_results, reporting_meter_data, reporting_temperature_data
 ):
-    baseline_model.model_params = None
+    baseline_model_results.model.model_params = None
     with pytest.raises(MissingModelParameterError):
         caltrack_metered_savings(
-            baseline_model, reporting_meter_data, reporting_temperature_data,
-            degree_day_method='daily'
+            baseline_model_results, reporting_meter_data, reporting_temperature_data,
+            degree_day_method='daily', frequency='daily', t_stat=1.649
         )
 
 
 def test_caltrack_metered_savings_cdd_hdd_with_disaggregated(
-    baseline_model, reporting_meter_data, reporting_temperature_data
+    baseline_model_results, reporting_meter_data, reporting_temperature_data
 ):
 
-    results = caltrack_metered_savings(
-        baseline_model, reporting_meter_data, reporting_temperature_data,
-        degree_day_method='daily', with_disaggregated=True
+    results, error_bands = caltrack_metered_savings(
+        baseline_model_results, reporting_meter_data, reporting_temperature_data,
+        degree_day_method='daily', with_disaggregated=True, frequency='daily', t_stat=1.649
     )
     assert list(sorted(results.columns)) == [
         'counterfactual_base_load',

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -9,6 +9,8 @@ from eemeter import (
 from eemeter.metrics import (
     _compute_r_squared,
     _compute_r_squared_adj,
+    _compute_rmse,
+    _compute_rmse_adj,
     _compute_cvrmse,
     _compute_cvrmse_adj,
     _compute_mape,
@@ -127,12 +129,17 @@ def test_compute_r_squared_adj(sample_data_merged):
     
 def test_compute_cvrmse(sample_data_merged):
     combined = sample_data_merged
-    assert round(_compute_cvrmse(combined), 3) == 0.394
+    observed_mean = combined['observed'].mean()
+    assert round(_compute_cvrmse(_compute_rmse(combined),observed_mean), 3) == 0.394
     
     
 def test_compute_cvrmse_adj(sample_data_merged):
     combined = sample_data_merged
-    assert round(_compute_cvrmse_adj(combined, 5, 2), 3) == 0.509
+    observed_mean = combined['observed'].mean()
+    observed_length = len(combined['observed'])
+    num_parameters = 2
+    assert round(_compute_cvrmse_adj(_compute_rmse_adj(combined, observed_length,
+        num_parameters), observed_mean), 3) == 0.509
     
     
 def test_compute_mape(sample_data_merged):


### PR DESCRIPTION
1. Changed caltrack_metered_savings() so that it takes in a ModelResults object (instead of a CandidateModel), and takes in frequency and t-statistic arguments. (In the future we'll generate the t-stat automatically, but we weren't sure we wanted to make importing scipy a requirement of using the library, so we're deciding what to do.) Caltrack_metered_savings() then calculates fractional savings uncertainty error bands (which can easily be converted to fractional savings uncertainty by dividing by total estimated savings, or can be aggregated up to a portfolio level). It also calculates OLS error bands. Both of these are returned -- along with the constituent parts of the OLS error band (model error and noise) -- as a dictionary.
2. Altered caltrack_method so that it returns a ModelResults object with two sets of attached ModelMetrics objects -- one for the inputs as averages, and one for the inputs as totals. This was necessary because up to this point, caltrack_method had only been creating a ModelMetrics object for averages, and when computing these error bands, we wanted to use the saved metrics numbers for totals.
3. Added variance and RMSE to the ModelMetrics class.
4. Changed _caltrack_predict_design_matrix so that it throws an error if it receives a dataframe without a DatetimeIndex or an "n_days" column. Also made it so that it gives results that have NaNs for rows if the input data had any observation that was a NaN in that row.
5. Updated the tests. Did not get to 100% coverage because I ran out of time, but we are very close. 

