### PR TITLE
apply json float on other metrics

### DIFF
--- a/eemeter/metrics.py
+++ b/eemeter/metrics.py
@@ -257,9 +257,9 @@ class ModelMetrics(object):
         with :any:`json.dumps`.
         """
         return {
-            "observed_length": self.observed_length,
-            "predicted_length": self.predicted_length,
-            "merged_length": self.merged_length,
+            "observed_length": _json_safe_float(self.observed_length),
+            "predicted_length": _json_safe_float(self.predicted_length),
+            "merged_length": _json_safe_float(self.merged_length),
             "observed_mean": _json_safe_float(self.observed_mean),
             "predicted_mean": _json_safe_float(self.predicted_mean),
             "observed_skew": _json_safe_float(self.observed_skew),
@@ -273,8 +273,8 @@ class ModelMetrics(object):
             "cvrmse": _json_safe_float(self.cvrmse),
             "cvrmse_adj": _json_safe_float(self.cvrmse_adj),
             "mape": _json_safe_float(self.mape),
-            "mape_no_zeros": self.mape_no_zeros,
-            "num_meter_zeros": self.num_meter_zeros,
+            "mape_no_zeros": _json_safe_float(self.mape_no_zeros),
+            "num_meter_zeros": _json_safe_float(self.num_meter_zeros),
             "nmae": _json_safe_float(self.nmae),
             "nmbe": _json_safe_float(self.nmbe),
             "autocorr_resid": _json_safe_float(self.autocorr_resid),


### PR DESCRIPTION
I have performed unit testing.

I was running into another NaN issue:

django.db.utils.DataError: invalid input syntax for type json
LINE 1: ...e', '{"intercept": 0.0}', '{"r_squared_adj": 0}', '{"status"...
                                                             ^
DETAIL:  Token "NaN" is invalid.
CONTEXT:  JSON data, line 1: ...se_adj": null, "mape": null, "mape_no_zeros": NaN...

