### PR TITLE
changed how degree day columns are added for empty temp traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 Development
 -----------
 
-* [placeholder]
+* Fix bug related to caltrack billing design matrix creation during empty temperature traces.
 
 2.1.2
 -----

--- a/eemeter/features.py
+++ b/eemeter/features.py
@@ -439,15 +439,14 @@ def compute_temperature_features(
         )
         del df["meter_value"]
 
-        if df.empty:
-            if "degree_day_columns" in df:
+        if "degree_day_columns" in df:
+            if df["degree_day_columns"].dropna().empty:
                 column_defaults = {
-                    column: [] for column in ["n_days_dropped", "n_days_kept"]
+                    column: np.full(df["degree_day_columns"].shape, np.nan)
+                    for column in ["n_days_dropped", "n_days_kept"]
                 }
                 df = df.drop(["degree_day_columns"], axis=1).assign(**column_defaults)
-        else:
-            # expand degree_day_columns
-            if "degree_day_columns" in df:
+            else:
                 df = pd.concat(
                     [
                         df.drop(["degree_day_columns"], axis=1),

--- a/tests/test_caltrack_design_matrices.py
+++ b/tests/test_caltrack_design_matrices.py
@@ -170,6 +170,7 @@ def test_create_caltrack_daily_design_matrix(il_electricity_cdd_hdd_daily):
     ]
     assert round(design_matrix.sum().sum(), 2) == 167795.89
 
+
 def test_create_caltrack_billing_design_matrix(il_electricity_cdd_hdd_billing_monthly):
     meter_data = il_electricity_cdd_hdd_billing_monthly["meter_data"]
     temperature_data = il_electricity_cdd_hdd_billing_monthly["temperature_data"]
@@ -376,19 +377,23 @@ def test_create_caltrack_hourly_segmented_design_matrices(
     assert round(design_matrix.sum().sum(), 2) == 0.0
 
 
-def test_create_caltrack_billing_design_matrix_empty_temp(il_electricity_cdd_hdd_billing_monthly):
+def test_create_caltrack_billing_design_matrix_empty_temp(
+    il_electricity_cdd_hdd_billing_monthly
+):
     meter_data = il_electricity_cdd_hdd_billing_monthly["meter_data"]
     temperature_data = il_electricity_cdd_hdd_billing_monthly["temperature_data"][:0]
     design_matrix = create_caltrack_billing_design_matrix(
         meter_data[:10], temperature_data
     )
-    assert 'n_days_kept' in design_matrix.columns
+    assert "n_days_kept" in design_matrix.columns
 
 
-def test_create_caltrack_billing_design_matrix_partial_empty_temp(il_electricity_cdd_hdd_billing_monthly):
+def test_create_caltrack_billing_design_matrix_partial_empty_temp(
+    il_electricity_cdd_hdd_billing_monthly
+):
     meter_data = il_electricity_cdd_hdd_billing_monthly["meter_data"]
     temperature_data = il_electricity_cdd_hdd_billing_monthly["temperature_data"][:200]
     design_matrix = create_caltrack_billing_design_matrix(
         meter_data[:10], temperature_data
     )
-    assert 'n_days_kept' in design_matrix.columns
+    assert "n_days_kept" in design_matrix.columns

--- a/tests/test_caltrack_design_matrices.py
+++ b/tests/test_caltrack_design_matrices.py
@@ -170,7 +170,6 @@ def test_create_caltrack_daily_design_matrix(il_electricity_cdd_hdd_daily):
     ]
     assert round(design_matrix.sum().sum(), 2) == 167795.89
 
-
 def test_create_caltrack_billing_design_matrix(il_electricity_cdd_hdd_billing_monthly):
     meter_data = il_electricity_cdd_hdd_billing_monthly["meter_data"]
     temperature_data = il_electricity_cdd_hdd_billing_monthly["temperature_data"]
@@ -375,3 +374,21 @@ def test_create_caltrack_hourly_segmented_design_matrices(
         "weight",
     ]
     assert round(design_matrix.sum().sum(), 2) == 0.0
+
+
+def test_create_caltrack_billing_design_matrix_empty_temp(il_electricity_cdd_hdd_billing_monthly):
+    meter_data = il_electricity_cdd_hdd_billing_monthly["meter_data"]
+    temperature_data = il_electricity_cdd_hdd_billing_monthly["temperature_data"][:0]
+    design_matrix = create_caltrack_billing_design_matrix(
+        meter_data[:10], temperature_data
+    )
+    assert 'n_days_kept' in design_matrix.columns
+
+
+def test_create_caltrack_billing_design_matrix_partial_empty_temp(il_electricity_cdd_hdd_billing_monthly):
+    meter_data = il_electricity_cdd_hdd_billing_monthly["meter_data"]
+    temperature_data = il_electricity_cdd_hdd_billing_monthly["temperature_data"][:200]
+    design_matrix = create_caltrack_billing_design_matrix(
+        meter_data[:10], temperature_data
+    )
+    assert 'n_days_kept' in design_matrix.columns


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [X] Make sure you are requesting to **pull a feature/bugfix branch** (right side). Don't request your master!
- [X] Make sure tests pass and coverage has not fallen `docker-compose run --rm test`.
- [X] Update the [CHANGELOG.md](../CHANGELOG.md) to describe your changes in a bulletted list under the "Development" section at the top of the changelog. If this section does not exist, create it.
- [X] Make sure code style follows PEP 008 using `docker-compose run --rm blacken`.

### Description

Fixed bug relating to caltrack billing design matrices with empty temperature traces.