### PR TITLE
Fix/fsu billing data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 Development
 -----------
 
-* [placeholder]
+* Fix bug in fractional savings uncertainty calculations using billing data.
 
 2.2.0
 -----

--- a/eemeter/derivatives.py
+++ b/eemeter/derivatives.py
@@ -26,7 +26,9 @@ def _compute_ols_error(
         t_stat * rmse_base_residuals * (post_obs * base_obs / nprime) ** 0.5
     )
 
-    ols_total_agg_error = (ols_model_agg_error ** 2.0 + ols_noise_agg_error ** 2.0) ** 0.5
+    ols_total_agg_error = (
+        ols_model_agg_error ** 2.0 + ols_noise_agg_error ** 2.0
+    ) ** 0.5
 
     return ols_total_agg_error, ols_model_agg_error, ols_noise_agg_error
 
@@ -261,14 +263,18 @@ def _compute_error_bands_modeled_savings(
 
     base_obs_baseline = float(totals_metrics_baseline.observed_length)
     base_obs_reporting = float(totals_metrics_reporting.observed_length)
-    
+
     if interval_baseline.startswith("billing") & len(results.dropna().index) > 0:
-        post_obs_baseline = float(round((results.index[-1] - results.index[0]).days / 30.0))
+        post_obs_baseline = float(
+            round((results.index[-1] - results.index[0]).days / 30.0)
+        )
     else:
         post_obs_baseline = float(results["modeled_baseline_usage"].dropna().shape[0])
-    
+
     if interval_reporting.startswith("billing") & len(results.dropna().index) > 0:
-        post_obs_reporting = float(round((results.index[-1] - results.index[0]).days / 30.0))
+        post_obs_reporting = float(
+            round((results.index[-1] - results.index[0]).days / 30.0)
+        )
     else:
         post_obs_reporting = float(results["modeled_reporting_usage"].dropna().shape[0])
 
@@ -345,7 +351,9 @@ def _compute_error_bands_modeled_savings(
     return {
         "FSU Error Band: Baseline": fsu_error_band_baseline,
         "FSU Error Band: Reporting": fsu_error_band_reporting,
-        "FSU Error Band": (fsu_error_band_baseline ** 2.0 + fsu_error_band_reporting ** 2.0)
+        "FSU Error Band": (
+            fsu_error_band_baseline ** 2.0 + fsu_error_band_reporting ** 2.0
+        )
         ** 0.5,
     }
 

--- a/eemeter/derivatives.py
+++ b/eemeter/derivatives.py
@@ -68,7 +68,10 @@ def _compute_error_bands_metered_savings(
     num_parameters = float(totals_metrics.num_parameters)
 
     base_obs = float(totals_metrics.observed_length)
-    post_obs = float(results["reporting_observed"].dropna().shape[0])
+    if interval.startswith("billing") & len(results.dropna().index) > 0:
+        post_obs = float(round((results.index[-1] - results.index[0]).days / 30.0))
+    else:
+        post_obs = float(results["reporting_observed"].dropna().shape[0])
 
     degrees_of_freedom = float(base_obs - num_parameters)
     single_tailed_confidence_level = 1 - ((1 - confidence_level) / 2)
@@ -258,8 +261,16 @@ def _compute_error_bands_modeled_savings(
 
     base_obs_baseline = float(totals_metrics_baseline.observed_length)
     base_obs_reporting = float(totals_metrics_reporting.observed_length)
-    post_obs_baseline = float(results["modeled_baseline_usage"].dropna().shape[0])
-    post_obs_reporting = float(results["modeled_reporting_usage"].dropna().shape[0])
+    
+    if interval_baseline.startswith("billing") & len(results.dropna().index) > 0:
+        post_obs_baseline = float(round((results.index[-1] - results.index[0]).days / 30.0))
+    else:
+        post_obs_baseline = float(results["modeled_baseline_usage"].dropna().shape[0])
+    
+    if interval_reporting.startswith("billing") & len(results.dropna().index) > 0:
+        post_obs_reporting = float(round((results.index[-1] - results.index[0]).days / 30.0))
+    else:
+        post_obs_reporting = float(results["modeled_reporting_usage"].dropna().shape[0])
 
     degrees_of_freedom_baseline = float(base_obs_baseline - num_parameters_baseline)
     degrees_of_freedom_reporting = float(base_obs_reporting - num_parameters_reporting)

--- a/eemeter/derivatives.py
+++ b/eemeter/derivatives.py
@@ -70,7 +70,7 @@ def _compute_error_bands_metered_savings(
     num_parameters = float(totals_metrics.num_parameters)
 
     base_obs = float(totals_metrics.observed_length)
-    if interval.startswith("billing") & len(results.dropna().index) > 0:
+    if (interval.startswith("billing")) & (len(results.dropna().index) > 0):
         post_obs = float(round((results.index[-1] - results.index[0]).days / 30.0))
     else:
         post_obs = float(results["reporting_observed"].dropna().shape[0])
@@ -264,14 +264,14 @@ def _compute_error_bands_modeled_savings(
     base_obs_baseline = float(totals_metrics_baseline.observed_length)
     base_obs_reporting = float(totals_metrics_reporting.observed_length)
 
-    if interval_baseline.startswith("billing") & len(results.dropna().index) > 0:
+    if (interval_baseline.startswith("billing")) & (len(results.dropna().index) > 0):
         post_obs_baseline = float(
             round((results.index[-1] - results.index[0]).days / 30.0)
         )
     else:
         post_obs_baseline = float(results["modeled_baseline_usage"].dropna().shape[0])
 
-    if interval_reporting.startswith("billing") & len(results.dropna().index) > 0:
+    if (interval_reporting.startswith("billing")) & (len(results.dropna().index) > 0):
         post_obs_reporting = float(
             round((results.index[-1] - results.index[0]).days / 30.0)
         )

--- a/tests/test_derivatives.py
+++ b/tests/test_derivatives.py
@@ -551,6 +551,7 @@ def test_modeled_savings_cdd_hdd_billing(
         "FSU Error Band: Baseline",
         "FSU Error Band: Reporting",
     ]
+    assert round(error_bands["FSU Error Band"], 2) == 156.89
 
 
 @pytest.fixture

--- a/tests/test_derivatives.py
+++ b/tests/test_derivatives.py
@@ -531,16 +531,14 @@ def normal_year_temperature_data():
 
 
 def test_modeled_savings_cdd_hdd_billing(
-    baseline_model_billing,
-    reporting_model_billing,
-    normal_year_temperature_data
+    baseline_model_billing, reporting_model_billing, normal_year_temperature_data
 ):
 
     results, error_bands = modeled_savings(
         baseline_model_billing,
         reporting_model_billing,
         pd.date_range("2015-01-01", freq="D", periods=365, tz="UTC"),
-        normal_year_temperature_data
+        normal_year_temperature_data,
     )
     assert list(results.columns) == [
         "modeled_baseline_usage",

--- a/tests/test_derivatives.py
+++ b/tests/test_derivatives.py
@@ -127,6 +127,24 @@ def baseline_model_billing(il_electricity_cdd_hdd_billing_monthly):
 
 
 @pytest.fixture
+def reporting_model_billing(il_electricity_cdd_hdd_billing_monthly):
+    meter_data = il_electricity_cdd_hdd_billing_monthly["meter_data"]
+    meter_data.value = meter_data.value - 50
+    temperature_data = il_electricity_cdd_hdd_billing_monthly["temperature_data"]
+    blackout_start_date = il_electricity_cdd_hdd_billing_monthly["blackout_start_date"]
+    baseline_meter_data, warnings = get_baseline_data(
+        meter_data, end=blackout_start_date
+    )
+    baseline_data = create_caltrack_billing_design_matrix(
+        baseline_meter_data, temperature_data
+    )
+    model_results = fit_caltrack_usage_per_day_model(
+        baseline_data, use_billing_presets=True, weights_col="n_days_kept"
+    )
+    return model_results
+
+
+@pytest.fixture
 def reporting_meter_data_billing():
     index = pd.date_range("2011-01-01", freq="MS", periods=13, tz="UTC")
     return pd.DataFrame({"value": 1}, index=index)
@@ -503,6 +521,38 @@ def test_modeled_savings_cdd_hdd_hourly(
     ]
     assert round(results.modeled_savings.sum(), 2) == 20.76
     assert error_bands is None
+
+
+@pytest.fixture
+def normal_year_temperature_data():
+    index = pd.date_range("2015-01-01", freq="D", periods=365, tz="UTC")
+    np.random.seed(0)
+    return pd.Series(np.random.rand(365) * 30 + 45, index=index).asfreq("H").ffill()
+
+
+def test_modeled_savings_cdd_hdd_billing(
+    baseline_model_billing,
+    reporting_model_billing,
+    normal_year_temperature_data
+):
+
+    results, error_bands = modeled_savings(
+        baseline_model_billing,
+        reporting_model_billing,
+        pd.date_range("2015-01-01", freq="D", periods=365, tz="UTC"),
+        normal_year_temperature_data
+    )
+    assert list(results.columns) == [
+        "modeled_baseline_usage",
+        "modeled_reporting_usage",
+        "modeled_savings",
+    ]
+    assert round(results.modeled_savings.sum(), 2) == 587.44
+    assert sorted(error_bands.keys()) == [
+        "FSU Error Band",
+        "FSU Error Band: Baseline",
+        "FSU Error Band: Reporting",
+    ]
 
 
 @pytest.fixture


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [X] Make sure you are requesting to **pull a feature/bugfix branch** (right side). Don't request your master!
- [X] Make sure tests pass and coverage has not fallen `docker-compose run --rm test`.
- [X] Update the [CHANGELOG.md](../CHANGELOG.md) to describe your changes in a bulleted list under the "Development" section at the top of the changelog. If this section does not exist, create it.
- [X] Make sure code style follows PEP 008 using `docker-compose run --rm blacken`.

### Description

FSU calculations were using the length of the results dataframe to determine the number of intervals in the post-period, which is ok for daily data, but not correct if daily results are passed with a billing model.
