### PR TITLE
Updated to include warning for extreme values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 Development
 -----------
 
-* [placeholder]
+* Add warning to `caltrack_sufficiency_criteria` regarding extreme values.
 
 2.2.1
 -----

--- a/eemeter/caltrack/usage_per_day.py
+++ b/eemeter/caltrack/usage_per_day.py
@@ -1860,7 +1860,6 @@ def caltrack_sufficiency_criteria(
         at ``0.9`` (section 2.2.1.2), and requested_start and requested_end must
         not be None (section 2.2.4).
 
-    TODO: add warning for outliers (CalTrack 2.3.6)
 
     Parameters
     ----------
@@ -2088,6 +2087,7 @@ def caltrack_sufficiency_criteria(
 
     non_critical_warnings = []
     if n_extreme_values > 0:
+        # CalTRACK 2.3.6
         non_critical_warnings.append(
             EEMeterWarning(
                 qualified_name=(

--- a/eemeter/caltrack/usage_per_day.py
+++ b/eemeter/caltrack/usage_per_day.py
@@ -2091,8 +2091,7 @@ def caltrack_sufficiency_criteria(
         non_critical_warnings.append(
             EEMeterWarning(
                 qualified_name=(
-                    "eemeter.caltrack_sufficiency_criteria"
-                    ".extreme_values_detected"
+                    "eemeter.caltrack_sufficiency_criteria" ".extreme_values_detected"
                 ),
                 description=(
                     "Extreme values (greater than (median + (3 * IQR)),"
@@ -2108,7 +2107,6 @@ def caltrack_sufficiency_criteria(
                 },
             )
         )
-
 
     warnings = critical_warnings + non_critical_warnings
 

--- a/tests/test_caltrack_usage_per_day.py
+++ b/tests/test_caltrack_usage_per_day.py
@@ -1670,6 +1670,42 @@ def test_caltrack_sufficiency_criteria_pass():
     }
 
 
+def test_caltrack_sufficiency_criteria_pass_extreme_value_warning():
+    data_quality = pd.DataFrame(
+        {
+            "meter_value": [1, 1, 99999, 1, np.nan],
+            "temperature_not_null": np.ones(5),
+            "temperature_null": np.zeros(5),
+            "start": pd.date_range(start="2016-01-02", periods=5, freq="D", tz="UTC"),
+        }
+    ).set_index("start")
+    requested_start = pd.Timestamp("2016-01-02").tz_localize("UTC").to_pydatetime()
+    requested_end = pd.Timestamp("2016-01-06").tz_localize("UTC")
+    data_sufficiency = caltrack_sufficiency_criteria(
+        data_quality,
+        requested_start,
+        requested_end,
+        num_days=4,
+        min_fraction_daily_coverage=0.9,
+        min_fraction_hourly_temperature_coverage_per_period=0.9,
+    )
+    assert data_sufficiency.status == "PASS"
+    assert data_sufficiency.criteria_name == ("caltrack_sufficiency_criteria")
+    assert len(data_sufficiency.warnings) == 1
+
+    warning0 = data_sufficiency.warnings[0]
+    assert warning0.qualified_name == (
+        "eemeter.caltrack_sufficiency_criteria.extreme_values_detected"
+    )
+    assert warning0.data['n_extreme_values'] == 1
+    assert data_sufficiency.settings == {
+        "num_days": 4,
+        "min_fraction_daily_coverage": 0.9,
+        "min_fraction_hourly_temperature_coverage_per_period": 0.9,
+    }
+
+
+
 def test_caltrack_sufficiency_criteria_fail_no_data():
     data_quality = pd.DataFrame(
         {

--- a/tests/test_caltrack_usage_per_day.py
+++ b/tests/test_caltrack_usage_per_day.py
@@ -1697,13 +1697,12 @@ def test_caltrack_sufficiency_criteria_pass_extreme_value_warning():
     assert warning0.qualified_name == (
         "eemeter.caltrack_sufficiency_criteria.extreme_values_detected"
     )
-    assert warning0.data['n_extreme_values'] == 1
+    assert warning0.data["n_extreme_values"] == 1
     assert data_sufficiency.settings == {
         "num_days": 4,
         "min_fraction_daily_coverage": 0.9,
         "min_fraction_hourly_temperature_coverage_per_period": 0.9,
     }
-
 
 
 def test_caltrack_sufficiency_criteria_fail_no_data():


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure tests pass and coverage has not fallen `docker-compose run --rm test`.
- [x] Update the [CHANGELOG.md](../CHANGELOG.md) to describe your changes in a bulleted list under the "Development" section at the top of the changelog. If this section does not exist, create it.
- [x] Make sure code style follows PEP 008 using `docker-compose run --rm blacken`.

### Description

This adds '2.3.6. Extreme values: Usage values that are more than three interquartile ranges larger than the median usage should be flagged as outliers and manually reviewed' as a non-critical warning to `eemeter.caltrack_sufficiency_criteria`.
