### PR TITLE
Made value in warning a float so if the raw data is np.int64 the warn…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 Development
 -----------
 
-* Placeholder
+* Change max_value to float so that it can be json serialized even if the input is int64s.
 
 2.2.2
 -----

--- a/eemeter/caltrack/usage_per_day.py
+++ b/eemeter/caltrack/usage_per_day.py
@@ -2011,7 +2011,7 @@ def caltrack_sufficiency_criteria(
     n_extreme_values = data_quality.meter_value[
         data_quality.meter_value > extreme_value_limit
     ].shape[0]
-    max_value = data_quality.meter_value.max()
+    max_value = float(data_quality.meter_value.max())
 
     if n_days_total > 0:
         fraction_valid_meter_value_days = n_valid_meter_value_days / float(n_days_total)


### PR DESCRIPTION
…ing can still be json serializable.

### Your checklist for this pull request

Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] Make sure you are requesting to **pull a feature/bugfix branch** (right side). Don't request your master!
- [ ] Make sure tests pass and coverage has not fallen `docker-compose run --rm test`.
- [ ] Update the [CHANGELOG.md](../CHANGELOG.md) to describe your changes in a bulleted list under the "Development" section at the top of the changelog. If this section does not exist, create it.
- [ ] Make sure code style follows PEP 008 using `docker-compose run --rm blacken`.

### Description

Makes a value that was going into a warning a float. This is important in case the warning needs to be dumped to json and the initial data is np.int64 (since json.dumps() doesn't always work on np.int64 values).
