### PR TITLE
Fix/warehouse temperature averaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 Development
 -----------
 
-* Placeholder
+* Added option in `transform.as_freq` to handle instantaneous data such as temperature and other weather variables.
 
 2.2.9
 -----

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -65,6 +65,39 @@ def test_as_freq_month_start(il_electricity_cdd_hdd_billing_monthly):
     assert round(meter_data.value.sum(), 1) == round(as_month_start.sum(), 1) == 21290.2
 
 
+def test_as_freq_hourly_temperature(il_electricity_cdd_hdd_billing_monthly):
+    temperature_data = il_electricity_cdd_hdd_billing_monthly["temperature_data"]
+    assert temperature_data.shape == (19417, )
+    as_hourly = as_freq(temperature_data, freq="H", series_type='instantaneous')
+    assert as_hourly.shape == (19417,)
+    assert round(temperature_data.mean(), 1) == round(as_hourly.mean(), 1) == 54.6
+
+
+def test_as_freq_daily_temperature(il_electricity_cdd_hdd_billing_monthly):
+    temperature_data = il_electricity_cdd_hdd_billing_monthly["temperature_data"]
+    assert temperature_data.shape == (19417, )
+    as_daily = as_freq(temperature_data, freq="D", series_type='instantaneous')
+    assert as_daily.shape == (810,)
+    assert abs(temperature_data.mean() - as_daily.mean()) <= 0.1
+
+
+def test_as_freq_month_start_temperature(il_electricity_cdd_hdd_billing_monthly):
+    temperature_data = il_electricity_cdd_hdd_billing_monthly["temperature_data"]
+    assert temperature_data.shape == (19417, )
+    as_month_start = as_freq(temperature_data, freq="MS", series_type='instantaneous')
+    assert as_month_start.shape == (28,)
+    assert round(as_month_start.mean(), 1) == 53.4
+
+
+def test_as_freq_daily_temperature_monthly(il_electricity_cdd_hdd_billing_monthly):
+    temperature_data = il_electricity_cdd_hdd_billing_monthly["temperature_data"]
+    temperature_data = temperature_data.groupby(pd.Grouper(freq='MS')).mean()
+    assert temperature_data.shape == (28, )
+    as_daily = as_freq(temperature_data, freq="D", series_type='instantaneous')
+    assert as_daily.shape == (824,)
+    assert round(as_daily.mean(), 1) == 54.5
+
+
 def test_as_freq_empty():
     meter_data = pd.DataFrame({"value": []})
     empty_meter_data = as_freq(meter_data.value, freq="H")


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure tests pass and coverage has not fallen `docker-compose run --rm test`.
- [x] Update the [CHANGELOG.md](../CHANGELOG.md) to describe your changes in a bulleted list under the "Development" section at the top of the changelog. If this section does not exist, create it.
- [x] Make sure code style follows PEP 008 using `docker-compose run --rm blacken`.

### Description

The `eemeter.as_freq` function was written to handle data where the values indicated quantities aggregated over certain time intervals. This pull request adds an option to allow this function to handle values that are sampled instantaneously (e.g. temperature). For cumulative data, resampling to higher frequencies involves spreading a value over more granular time intervals and aggregation requires summing over longer time intervals. For instantaneous data, resampling to higher frequencies involves simply copying the same value for all smaller time intervals, while aggregation involves calculating the mean over longer time intervals. 
