### PR TITLE
Fix/billing data slicing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 Development
 -----------
 
-* Placeholder
+* Fix in `transform.get_baseline_data` and `transform.get_reporting_data` to enable pulling a full year of data even with irregular billing periods
 
 2.2.10
 ------

--- a/eemeter/transform.py
+++ b/eemeter/transform.py
@@ -197,8 +197,9 @@ def get_baseline_data(data, start=None, end=None, max_days=365):
         end = pytz.UTC.localize(pd.Timestamp.max)
         end_inf = True
     else:
+        baseline_data_end = data[:end].index.max()
         if max_days is not None:
-            min_start = end - timedelta(days=max_days)
+            min_start = baseline_data_end - timedelta(days=max_days)
             if start < min_start:
                 start = min_start
 
@@ -287,8 +288,9 @@ def get_reporting_data(data, start=None, end=None, max_days=365):
         start = pytz.UTC.localize(pd.Timestamp.min)
         start_inf = True
     else:
+        reporting_data_start = data[start:].index.min()
         if max_days is not None:
-            max_end = start + timedelta(days=max_days)
+            max_end = reporting_data_start + timedelta(days=max_days)
             if end > max_end:
                 end = max_end
 

--- a/tests/test_derivatives.py
+++ b/tests/test_derivatives.py
@@ -162,7 +162,7 @@ def test_metered_savings_cdd_hdd_billing(
         "counterfactual_usage",
         "metered_savings",
     ]
-    assert round(results.metered_savings.sum(), 2) == 1625.73
+    assert round(results.metered_savings.sum(), 2) == 1626.39
     assert sorted(error_bands.keys()) == [
         "FSU Error Band",
         "OLS Error Band",
@@ -545,13 +545,13 @@ def test_modeled_savings_cdd_hdd_billing(
         "modeled_reporting_usage",
         "modeled_savings",
     ]
-    assert round(results.modeled_savings.sum(), 2) == 587.44
+    assert round(results.modeled_savings.sum(), 2) == 592.54
     assert sorted(error_bands.keys()) == [
         "FSU Error Band",
         "FSU Error Band: Baseline",
         "FSU Error Band: Reporting",
     ]
-    assert round(error_bands["FSU Error Band"], 2) == 156.89
+    assert round(error_bands["FSU Error Band"], 2) == 166.57
 
 
 @pytest.fixture


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [X] Make sure you are requesting to **pull a feature/bugfix branch** (right side). Don't request your master!
- [X] Make sure tests pass and coverage has not fallen `docker-compose run --rm test`.
- [X] Update the [CHANGELOG.md](../CHANGELOG.md) to describe your changes in a bulleted list under the "Development" section at the top of the changelog. If this section does not exist, create it.
- [X] Make sure code style follows PEP 008 using `docker-compose run --rm blacken`.

### Description

For billing data with irregular billing dates, the `get_baseline_data` and `get_reporting_data` functions were pulling only 11 months of data if the `end` arg did not coincide with a billing date. This fix ensures that the `max_days` arg is calculated from the data that is actually available. It is recommended to also apply a tolerance on `max_days` when dealing with billing data. For example, if a full year of data is required `max_days` could be set to 375 days (10 day tolerance). This is because 12 billing periods may have more than 365 days, but dropping a whole billing period that causes the total to just exceed 365 days would drop a whole month of data.
