### PR TITLE
Fix/hourly model single occupancy mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 Development
 -----------
 
-* Placeholder
+* Fix for bug that occasionally leads to `LinAlgError: SVD did not converge` error when fitting caltrack hourly models by addressing multi-collinearity when only a single occupancy mode is detected
 
 2.3.1
 -----

--- a/eemeter/caltrack/hourly.py
+++ b/eemeter/caltrack/hourly.py
@@ -151,12 +151,16 @@ def fit_caltrack_hourly_model_segment(segment_name, segment_data):
             bin_occupancy_interactions = "".join(
                 [" + {}".format(c) for c in data.columns if "bin" in c]
             )
-            return "meter_value ~ C(hour_of_week) - 1{}".format(bin_occupancy_interactions)
+            return "meter_value ~ C(hour_of_week) - 1{}".format(
+                bin_occupancy_interactions
+            )
         else:
             bin_occupancy_interactions = "".join(
                 [" + {}:C(occupancy)".format(c) for c in data.columns if "bin" in c]
             )
-            return "meter_value ~ C(hour_of_week) - 1{}".format(bin_occupancy_interactions)
+            return "meter_value ~ C(hour_of_week) - 1{}".format(
+                bin_occupancy_interactions
+            )
 
     warnings = []
     if segment_data.dropna().empty:

--- a/eemeter/caltrack/hourly.py
+++ b/eemeter/caltrack/hourly.py
@@ -147,7 +147,10 @@ def caltrack_hourly_prediction_feature_processor(
 
 def fit_caltrack_hourly_model_segment(segment_name, segment_data):
     def _get_hourly_model_formula(data):
-        if np.sum(data.loc[data.weight > 0].occupancy) == 0:
+        if (np.sum(data.loc[data.weight > 0].occupancy) == 0) or (
+            np.sum(data.loc[data.weight > 0].occupancy)
+            == len(data.loc[data.weight > 0].occupancy)
+        ):
             bin_occupancy_interactions = "".join(
                 [" + {}".format(c) for c in data.columns if "bin" in c]
             )

--- a/tests/test_caltrack_hourly.py
+++ b/tests/test_caltrack_hourly.py
@@ -363,35 +363,37 @@ def test_predict_caltrack_hourly_model_empty_models(
     assert prediction.dropna().shape[0] == 0
 
 
-
 @pytest.fixture
 def occupancy_lookup_zeroes():
     index = pd.Categorical(range(168))
     occupancy = pd.Series([False] * 168, index=index)
     return pd.DataFrame(
-        {
-            "dec-jan-feb-weighted": occupancy,
-            "jan-feb-mar-weighted": occupancy
-        }
+        {"dec-jan-feb-weighted": occupancy, "jan-feb-mar-weighted": occupancy}
     )
 
 
 @pytest.fixture
-def segmented_design_matrices_single_mode(segmented_data, occupancy_lookup_zeroes, temperature_bins):
+def segmented_design_matrices_single_mode(
+    segmented_data, occupancy_lookup_zeroes, temperature_bins
+):
     return {
         "dec-jan-feb-weighted": caltrack_hourly_fit_feature_processor(
-            "dec-jan-feb-weighted", segmented_data, occupancy_lookup_zeroes, temperature_bins
+            "dec-jan-feb-weighted",
+            segmented_data,
+            occupancy_lookup_zeroes,
+            temperature_bins,
         )
     }
 
 
-def test_fit_caltrack_hourly_model_segment_single_mode(segmented_design_matrices_single_mode):
+def test_fit_caltrack_hourly_model_segment_single_mode(
+    segmented_design_matrices_single_mode
+):
     segment_name = "dec-jan-feb-weighted"
     segment_data = segmented_design_matrices_single_mode[segment_name]
     segment_model = fit_caltrack_hourly_model_segment(segment_name, segment_data)
     assert segment_model.formula == (
-        "meter_value ~ C(hour_of_week) - 1 + bin_0"
-        " + bin_1 + bin_2 + bin_3"
+        "meter_value ~ C(hour_of_week) - 1 + bin_0" " + bin_1 + bin_2 + bin_3"
     )
     assert segment_model.segment_name == "dec-jan-feb-weighted"
     assert len(segment_model.model_params.keys()) == 28

--- a/tests/test_caltrack_hourly.py
+++ b/tests/test_caltrack_hourly.py
@@ -361,3 +361,41 @@ def test_predict_caltrack_hourly_model_empty_models(
     prediction = segmented_model.predict(temps.index, temps).result
     assert prediction.shape[0] == 24
     assert prediction.dropna().shape[0] == 0
+
+
+
+@pytest.fixture
+def occupancy_lookup_zeroes():
+    index = pd.Categorical(range(168))
+    occupancy = pd.Series([False] * 168, index=index)
+    return pd.DataFrame(
+        {
+            "dec-jan-feb-weighted": occupancy,
+            "jan-feb-mar-weighted": occupancy
+        }
+    )
+
+
+@pytest.fixture
+def segmented_design_matrices_single_mode(segmented_data, occupancy_lookup_zeroes, temperature_bins):
+    return {
+        "dec-jan-feb-weighted": caltrack_hourly_fit_feature_processor(
+            "dec-jan-feb-weighted", segmented_data, occupancy_lookup_zeroes, temperature_bins
+        )
+    }
+
+
+def test_fit_caltrack_hourly_model_segment_single_mode(segmented_design_matrices_single_mode):
+    segment_name = "dec-jan-feb-weighted"
+    segment_data = segmented_design_matrices_single_mode[segment_name]
+    segment_model = fit_caltrack_hourly_model_segment(segment_name, segment_data)
+    assert segment_model.formula == (
+        "meter_value ~ C(hour_of_week) - 1 + bin_0"
+        " + bin_1 + bin_2 + bin_3"
+    )
+    assert segment_model.segment_name == "dec-jan-feb-weighted"
+    assert len(segment_model.model_params.keys()) == 28
+    assert segment_model.model is not None
+    assert segment_model.warnings is not None
+    prediction = segment_model.predict(segment_data)
+    assert round(prediction.sum(), 2) == 960.0


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [X] Make sure you are requesting to **pull a feature/bugfix branch** (right side). Don't request your master!
- [X] Make sure tests pass and coverage has not fallen `docker-compose run --rm test`.
- [X] Update the [CHANGELOG.md](../CHANGELOG.md) to describe your changes in a bulleted list under the "Development" section at the top of the changelog. If this section does not exist, create it.
- [X] Make sure code style follows PEP 008 using `docker-compose run --rm blacken`.

### Description

Very rarely, if a building's consumption patterns are erratic, the occupancy lookup predicted by `features.estimate_hour_of_week_occupancy` implies that all hours of the week are unoccupied, i.e. the building only has a single occupancy mode. In these cases, a convergence error may occur on some machines due to some variables in the regression being all zeroes. This fix addresses that issue by utilizing a single occupancy mode regression.
