### PR TITLE
Handle nulls in as_freq and add flexibility to get_baseline_data for billing data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ Changelog
 Development
 -----------
 
-* Placeholder
+* Add parameters to `get_baseline_data` and `get_reporting_data` to help make
+  these methods a bit more correct for billing data.
+* Preserve nulls properly in `as_freq`.
+* Update jupyter version to be compatible with latest tornado version.
 
 2.4.0
 -----

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -16,10 +16,10 @@
     "default": {
         "certifi": {
             "hashes": [
-                "sha256:47f9c83ef4c0c621eaef743f133f09fa8a74a9b75f037e8624f83bd1b6626cb7",
-                "sha256:993f830721089fef441cdfeb4b2c8c9df86f0c63239f06bd025a76a7daddb033"
+                "sha256:59b7658e26ca9c7339e00f8f4636cdfe59d34fa37b9b04f6f9e9926b3cece1a5",
+                "sha256:b26104d6835d1f5e49452a26eb2ff87fe7090b89dfcaee5ea2212697e1e1d7ae"
             ],
-            "version": "==2018.11.29"
+            "version": "==2019.3.9"
         },
         "chardet": {
             "hashes": [
@@ -189,19 +189,23 @@
         },
         "pyproj": {
             "hashes": [
-                "sha256:026074694f9e9a3110013802c5ceb2728070dbdde9f1038609f942845f4207d1",
-                "sha256:25e244b84da0b673e2969fdfe2d98f2f94c74a8baea1dd88928f2cf7c1410cba",
-                "sha256:30739f8f0dc266563643799609c5d404d48d6b412bdba1d2fef8eed7f5782c5f",
-                "sha256:379cf8afd80f254dc7ee30c2a7a499e71bcc0f33c435e46b6c0ea30496faacb2",
-                "sha256:569c764b391e31d4b156acb09acde9afb0c1bf1a71ca6e829e4677220ca64a56",
-                "sha256:56dc74a5aa0878d2332e4edd931687e5b8fb18edd242cf8cff60217ce4ef0720",
-                "sha256:5b1553d80b35c6582a79252fc2a4e5d82d95383fbbfc671650d6fe54e18bbb9c",
-                "sha256:629acc34d8c2ff6fa2875e6075555fcb17a033cd3e181613e8782110fcc2f6b1",
-                "sha256:a7fa5da448dcdbd787e70e21dcf6c71a14bc048db86027f2fc3fe005b9440b93",
-                "sha256:c6d7c3c11c9f8f043fb00658f2146c10e3e0e21b5459022ae5716994650d6a02",
-                "sha256:e0c02b1554b20c710d16d673817b2a89ff94738b0b537aead8ecb2edc4c4487b"
+                "sha256:0a4028717c5a6432e13e9f131d10b54f7b5c160a1b1bf798da33a01df5453c29",
+                "sha256:1644621d71f4add8c4b7cd5fcfb5977ac55463100d0983ca4766b7e700e29cd2",
+                "sha256:1790e8cfd7b7488446584382657209b880843b3339de684a55585c5809bb2545",
+                "sha256:2a7b47e21d2f8fd35aeeb9b5322cb079da13cc961178f0db21cb17cbeea2c40b",
+                "sha256:40e426475b8030b9cba0ff8de5454d2acb0224395ef55a450a62a12a9ffdfb2b",
+                "sha256:4a93b6856235aafbedb38ba1c5f6ae2ccfa3df6c119f0402f3c986ef466fc624",
+                "sha256:757095c417c856612e957ac0993fa742f338ade762458a5b4ca704d6036c7931",
+                "sha256:963a80afca7d4953a28ade2e8537ecbf736ea37e26b2a703f43cb2ad70e3f508",
+                "sha256:98639fc1fe43f28ae34cb432db178c782ab3659e1faf76c0c6d4a694f2478a5d",
+                "sha256:ac6176ba67e9184bb77748f2b31650d9a72ddf45beb1575555abe8160935964d",
+                "sha256:b6809270d6246a7a88ea5fe7e02165e0a9b67f048fee41fad41a53f569c43705",
+                "sha256:c6306fc7897237df34e1e9ead57fcc897b6e67273e0a126dbf141e08b64578f2",
+                "sha256:dbcf1600178521c8cedd6bbb9fc82b6596928260776ec4c14fa3f84674ee4821",
+                "sha256:ef241f6c0befe704f39f5832cac33dbf02c30834e45ca1bd00f21ce256b564a2",
+                "sha256:f1ed1235825c336af7f5d133355e0c7373bb694fcf96b46f45be104d88268b77"
             ],
-            "version": "==1.9.6"
+            "version": "==2.1.1"
         },
         "python-dateutil": {
             "hashes": [
@@ -284,10 +288,10 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:11ead7047ff3f394ed0d4b62aded6c5d970a9b718e1dc6add9f5e79442cc5b14"
+                "sha256:781fb7b9d194ed3fc596b8f0dd4623ff160e3e825dd8c15472376a438c19598b"
             ],
             "index": "pypi",
-            "version": "==1.3.0"
+            "version": "==1.3.1"
         },
         "statsmodels": {
             "hashes": [
@@ -400,10 +404,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:47f9c83ef4c0c621eaef743f133f09fa8a74a9b75f037e8624f83bd1b6626cb7",
-                "sha256:993f830721089fef441cdfeb4b2c8c9df86f0c63239f06bd025a76a7daddb033"
+                "sha256:59b7658e26ca9c7339e00f8f4636cdfe59d34fa37b9b04f6f9e9926b3cece1a5",
+                "sha256:b26104d6835d1f5e49452a26eb2ff87fe7090b89dfcaee5ea2212697e1e1d7ae"
             ],
-            "version": "==2018.11.29"
+            "version": "==2019.3.9"
         },
         "chardet": {
             "hashes": [
@@ -422,47 +426,47 @@
         },
         "coverage": {
             "hashes": [
-                "sha256:09e47c529ff77bf042ecfe858fb55c3e3eb97aac2c87f0349ab5a7efd6b3939f",
-                "sha256:0a1f9b0eb3aa15c990c328535655847b3420231af299386cfe5efc98f9c250fe",
-                "sha256:0cc941b37b8c2ececfed341444a456912e740ecf515d560de58b9a76562d966d",
-                "sha256:10e8af18d1315de936d67775d3a814cc81d0747a1a0312d84e27ae5610e313b0",
-                "sha256:1b4276550b86caa60606bd3572b52769860a81a70754a54acc8ba789ce74d607",
-                "sha256:1e8a2627c48266c7b813975335cfdea58c706fe36f607c97d9392e61502dc79d",
-                "sha256:2b224052bfd801beb7478b03e8a66f3f25ea56ea488922e98903914ac9ac930b",
-                "sha256:447c450a093766744ab53bf1e7063ec82866f27bcb4f4c907da25ad293bba7e3",
-                "sha256:46101fc20c6f6568561cdd15a54018bb42980954b79aa46da8ae6f008066a30e",
-                "sha256:4710dc676bb4b779c4361b54eb308bc84d64a2fa3d78e5f7228921eccce5d815",
-                "sha256:510986f9a280cd05189b42eee2b69fecdf5bf9651d4cd315ea21d24a964a3c36",
-                "sha256:5535dda5739257effef56e49a1c51c71f1d37a6e5607bb25a5eee507c59580d1",
-                "sha256:5a7524042014642b39b1fcae85fb37556c200e64ec90824ae9ecf7b667ccfc14",
-                "sha256:5f55028169ef85e1fa8e4b8b1b91c0b3b0fa3297c4fb22990d46ff01d22c2d6c",
-                "sha256:6694d5573e7790a0e8d3d177d7a416ca5f5c150742ee703f3c18df76260de794",
-                "sha256:6831e1ac20ac52634da606b658b0b2712d26984999c9d93f0c6e59fe62ca741b",
-                "sha256:77f0d9fa5e10d03aa4528436e33423bfa3718b86c646615f04616294c935f840",
-                "sha256:828ad813c7cdc2e71dcf141912c685bfe4b548c0e6d9540db6418b807c345ddd",
-                "sha256:85a06c61598b14b015d4df233d249cd5abfa61084ef5b9f64a48e997fd829a82",
-                "sha256:8cb4febad0f0b26c6f62e1628f2053954ad2c555d67660f28dfb1b0496711952",
-                "sha256:a5c58664b23b248b16b96253880b2868fb34358911400a7ba39d7f6399935389",
-                "sha256:aaa0f296e503cda4bc07566f592cd7a28779d433f3a23c48082af425d6d5a78f",
-                "sha256:ab235d9fe64833f12d1334d29b558aacedfbca2356dfb9691f2d0d38a8a7bfb4",
-                "sha256:b3b0c8f660fae65eac74fbf003f3103769b90012ae7a460863010539bb7a80da",
-                "sha256:bab8e6d510d2ea0f1d14f12642e3f35cefa47a9b2e4c7cea1852b52bc9c49647",
-                "sha256:c45297bbdbc8bb79b02cf41417d63352b70bcb76f1bbb1ee7d47b3e89e42f95d",
-                "sha256:d19bca47c8a01b92640c614a9147b081a1974f69168ecd494687c827109e8f42",
-                "sha256:d64b4340a0c488a9e79b66ec9f9d77d02b99b772c8b8afd46c1294c1d39ca478",
-                "sha256:da969da069a82bbb5300b59161d8d7c8d423bc4ccd3b410a9b4d8932aeefc14b",
-                "sha256:ed02c7539705696ecb7dc9d476d861f3904a8d2b7e894bd418994920935d36bb",
-                "sha256:ee5b8abc35b549012e03a7b1e86c09491457dba6c94112a2482b18589cc2bdb9"
+                "sha256:3684fabf6b87a369017756b551cef29e505cb155ddb892a7a29277b978da88b9",
+                "sha256:39e088da9b284f1bd17c750ac672103779f7954ce6125fd4382134ac8d152d74",
+                "sha256:3c205bc11cc4fcc57b761c2da73b9b72a59f8d5ca89979afb0c1c6f9e53c7390",
+                "sha256:465ce53a8c0f3a7950dfb836438442f833cf6663d407f37d8c52fe7b6e56d7e8",
+                "sha256:48020e343fc40f72a442c8a1334284620f81295256a6b6ca6d8aa1350c763bbe",
+                "sha256:5296fc86ab612ec12394565c500b412a43b328b3907c0d14358950d06fd83baf",
+                "sha256:5f61bed2f7d9b6a9ab935150a6b23d7f84b8055524e7be7715b6513f3328138e",
+                "sha256:68a43a9f9f83693ce0414d17e019daee7ab3f7113a70c79a3dd4c2f704e4d741",
+                "sha256:6b8033d47fe22506856fe450470ccb1d8ba1ffb8463494a15cfc96392a288c09",
+                "sha256:7ad7536066b28863e5835e8cfeaa794b7fe352d99a8cded9f43d1161be8e9fbd",
+                "sha256:7bacb89ccf4bedb30b277e96e4cc68cd1369ca6841bde7b005191b54d3dd1034",
+                "sha256:839dc7c36501254e14331bcb98b27002aa415e4af7ea039d9009409b9d2d5420",
+                "sha256:8f9a95b66969cdea53ec992ecea5406c5bd99c9221f539bca1e8406b200ae98c",
+                "sha256:932c03d2d565f75961ba1d3cec41ddde00e162c5b46d03f7423edcb807734eab",
+                "sha256:988529edadc49039d205e0aa6ce049c5ccda4acb2d6c3c5c550c17e8c02c05ba",
+                "sha256:998d7e73548fe395eeb294495a04d38942edb66d1fa61eb70418871bc621227e",
+                "sha256:9de60893fb447d1e797f6bf08fdf0dbcda0c1e34c1b06c92bd3a363c0ea8c609",
+                "sha256:9e80d45d0c7fcee54e22771db7f1b0b126fb4a6c0a2e5afa72f66827207ff2f2",
+                "sha256:a545a3dfe5082dc8e8c3eb7f8a2cf4f2870902ff1860bd99b6198cfd1f9d1f49",
+                "sha256:a5d8f29e5ec661143621a8f4de51adfb300d7a476224156a39a392254f70687b",
+                "sha256:aca06bfba4759bbdb09bf52ebb15ae20268ee1f6747417837926fae990ebc41d",
+                "sha256:bb23b7a6fd666e551a3094ab896a57809e010059540ad20acbeec03a154224ce",
+                "sha256:bfd1d0ae7e292105f29d7deaa9d8f2916ed8553ab9d5f39ec65bcf5deadff3f9",
+                "sha256:c62ca0a38958f541a73cf86acdab020c2091631c137bd359c4f5bddde7b75fd4",
+                "sha256:c709d8bda72cf4cd348ccec2a4881f2c5848fd72903c185f363d361b2737f773",
+                "sha256:c968a6aa7e0b56ecbd28531ddf439c2ec103610d3e2bf3b75b813304f8cb7723",
+                "sha256:df785d8cb80539d0b55fd47183264b7002077859028dfe3070cf6359bf8b2d9c",
+                "sha256:f406628ca51e0ae90ae76ea8398677a921b36f0bd71aab2099dfed08abd0322f",
+                "sha256:f46087bbd95ebae244a0eda01a618aff11ec7a069b15a3ef8f6b520db523dcf1",
+                "sha256:f8019c5279eb32360ca03e9fac40a12667715546eed5c5eb59eb381f2f501260",
+                "sha256:fc5f4d209733750afd2714e9109816a29500718b32dd9a5db01c0cb3a019b96a"
             ],
             "index": "pypi",
-            "version": "==4.5.2"
+            "version": "==4.5.3"
         },
         "decorator": {
             "hashes": [
-                "sha256:33cd704aea07b4c28b3eb2c97d288a06918275dac0ecebdaf1bc8a48d98adb9e",
-                "sha256:cabb249f4710888a2fc0e13e9a16c343d932033718ff62e1e9bc93a9d3a9122b"
+                "sha256:86156361c50488b84a3f148056ea716ca587df2f0de1d34750d35c21312725de",
+                "sha256:f069f3a01830ca754ba5258fde2278454a0b5b79e0d7f5c13b3b97e57d4acff6"
             ],
-            "version": "==4.3.2"
+            "version": "==4.4.0"
         },
         "defusedxml": {
             "hashes": [
@@ -687,10 +691,10 @@
         },
         "notebook": {
             "hashes": [
-                "sha256:3ab2db8bc10e6edbd264c3c4b800bee276c99818386ee0c146d98d7e6bcf0a67",
-                "sha256:d908673a4010787625c8952e91a22adf737db031f2aa0793ad92f6558918a74a"
+                "sha256:18a98858c0331fb65a60f2ebb6439f8c0c4defd14ca363731b6cabc7f61624b4",
+                "sha256:cc027a62be0f7756e0ef3d2d98458c4d7f4b3566449fb1a05891207f5bd9a1bf"
             ],
-            "version": "==5.7.4"
+            "version": "==5.7.6"
         },
         "packaging": {
             "hashes": [
@@ -865,49 +869,49 @@
         },
         "pyyaml": {
             "hashes": [
-                "sha256:3d7da3009c0f3e783b2c873687652d83b1bbfd5c88e9813fb7e5b03c0dd3108b",
-                "sha256:3ef3092145e9b70e3ddd2c7ad59bdd0252a94dfe3949721633e41344de00a6bf",
-                "sha256:40c71b8e076d0550b2e6380bada1f1cd1017b882f7e16f09a65be98e017f211a",
-                "sha256:558dd60b890ba8fd982e05941927a3911dc409a63dcb8b634feaa0cda69330d3",
-                "sha256:a7c28b45d9f99102fa092bb213aa12e0aaf9a6a1f5e395d36166639c1f96c3a1",
-                "sha256:aa7dd4a6a427aed7df6fb7f08a580d68d9b118d90310374716ae90b710280af1",
-                "sha256:bc558586e6045763782014934bfaf39d48b8ae85a2713117d16c39864085c613",
-                "sha256:d46d7982b62e0729ad0175a9bc7e10a566fc07b224d2c79fafb5e032727eaa04",
-                "sha256:d5eef459e30b09f5a098b9cea68bebfeb268697f78d647bd255a085371ac7f3f",
-                "sha256:e01d3203230e1786cd91ccfdc8f8454c8069c91bee3962ad93b87a4b2860f537",
-                "sha256:e170a9e6fcfd19021dd29845af83bb79236068bf5fd4df3327c1be18182b2531"
+                "sha256:1adecc22f88d38052fb787d959f003811ca858b799590a5eaa70e63dca50308c",
+                "sha256:436bc774ecf7c103814098159fbb84c2715d25980175292c648f2da143909f95",
+                "sha256:460a5a4248763f6f37ea225d19d5c205677d8d525f6a83357ca622ed541830c2",
+                "sha256:5a22a9c84653debfbf198d02fe592c176ea548cccce47553f35f466e15cf2fd4",
+                "sha256:7a5d3f26b89d688db27822343dfa25c599627bc92093e788956372285c6298ad",
+                "sha256:9372b04a02080752d9e6f990179a4ab840227c6e2ce15b95e1278456664cf2ba",
+                "sha256:a5dcbebee834eaddf3fa7366316b880ff4062e4bcc9787b78c7fbb4a26ff2dd1",
+                "sha256:aee5bab92a176e7cd034e57f46e9df9a9862a71f8f37cad167c6fc74c65f5b4e",
+                "sha256:c51f642898c0bacd335fc119da60baae0824f2cde95b0330b56c0553439f0673",
+                "sha256:c68ea4d3ba1705da1e0d85da6684ac657912679a649e8868bd850d2c299cce13",
+                "sha256:e23d0cc5299223dcc37885dae624f382297717e459ea24053709675a976a3e19"
             ],
-            "version": "==3.13"
+            "version": "==5.1"
         },
         "pyzmq": {
             "hashes": [
-                "sha256:07a03450418694fb07e76a0191b6bc9f411afc8e364ca2062edcf28bb0e51c63",
-                "sha256:15f0bf7cd80020f165635595e197603aedb37fddf4164ad5ae226afc43242f7b",
-                "sha256:1756dc72e192c670490e38c788c3a35f901adc74ee436e5131d5a3e85fdd7dc6",
-                "sha256:1d1eb490da54679d724b08ef3ee04530849023670c4ba7e400ed2cdf906720c4",
-                "sha256:228402625796821f08706f58cc42a3c51c9897d723550babaefe4feec2b6dacc",
-                "sha256:264ac9dcee6a7af2bce4b61f2d19e5926118a5caa629b50f107ef6318670a364",
-                "sha256:2b5a43da65f5dec857184d5c2ce13b80071019e96358f146bdecff7238765bc9",
-                "sha256:3928534fa00a2aabfcfdb439c08ba37fbe99ab0cf57776c8db8d2b73a51693ba",
-                "sha256:3d2a295b1086d450981f73d3561ac204a0cc9c8ded386a4a34327d918f3b1d0a",
-                "sha256:411def5b4cbe6111856040a55c8048df113882e90c57ce88de4a48f0189441ac",
-                "sha256:4b77e96a7ffc1c5e08eaf274db554f227b31717d086adca1bb42b12ef35a7194",
-                "sha256:4c87fa3e449e1f4ab9170cdfe8213dc0ba34a11b160e6adecafa892e451a29b6",
-                "sha256:4fd8621a309db6ec23ef1369f43cdf7a9b0dc217d8ff9ca4095a6e932b379bda",
-                "sha256:54fe55a1694ffe608c8e4c5183e83cab7a91f3e5c84bd6f188868d6676c12aba",
-                "sha256:60acabd86808a16a895a247fd2bf7a127284a33562d79687bb5df163cff068b2",
-                "sha256:618887be4ad754228c0cbba7631f6574608b4430fe93974e6322324f1304fdac",
-                "sha256:69130efb6efa936de601cb135a8a4eec1caccd4ea2b784237145ff4075c2d3ae",
-                "sha256:6e7f78eeac82140bde7e60e975c6e6b1b678a4dd377782ab63319c1c78bf3aa1",
-                "sha256:6ee760cdb84e43574da6b3f2f1fc1251e8acf87253900d28a06451c5f5de39e9",
-                "sha256:75c87f1dc1e65cea4b709f2ebc78fa18d4b475e41463502aec9cd26208b88e0f",
-                "sha256:97cb1b7cd2c46e87b0a26651eccd2bbb8c758035efd1635ebb81ac36aa76a88c",
-                "sha256:abfa774dbadacc849121ed92eae05189d226daab583388b499472e1bbb17ef69",
-                "sha256:ae3d2627d74195ddc95675f2f814aca998381b73dc4341b9e10e3e191e1bdb0b",
-                "sha256:b30c339eb58355f51f4f54dd61d785f1ff58c86bca1c3a5916977631d121867b",
-                "sha256:cbabdced5b137cd56aa22633f13ac5690029a0ad43ab6c05f53206e489178362"
+                "sha256:1651e52ed91f0736afd6d94ef9f3259b5534ce8beddb054f3d5ca989c4ef7c4f",
+                "sha256:5ccb9b3d4cd20c000a9b75689d5add8cd3bce67fcbd0f8ae1b59345247d803af",
+                "sha256:5e120c4cd3872e332fb35d255ad5998ebcee32ace4387b1b337416b6b90436c7",
+                "sha256:5e2a3707c69a7281a9957f83718815fd74698cba31f6d69f9ed359921f662221",
+                "sha256:63d51add9af8d0442dc90f916baf98fdc04e3b0a32afec4bfc83f8d85e72959f",
+                "sha256:65c5a0bdc49e20f7d6b03a661f71e2fda7a99c51270cafe71598146d09810d0d",
+                "sha256:66828fabe911aa545d919028441a585edb7c9c77969a5fea6722ef6e6ece38ab",
+                "sha256:7d79427e82d9dad6e9b47c0b3e7ae5f9d489b1601e3a36ea629bb49501a4daf3",
+                "sha256:824ee5d3078c4eae737ffc500fbf32f2b14e6ec89b26b435b7834febd70120cf",
+                "sha256:89dc0a83cccec19ff3c62c091e43e66e0183d1e6b4658c16ee4e659518131494",
+                "sha256:8b319805f6f7c907b101c864c3ca6cefc9db8ce0791356f180b1b644c7347e4c",
+                "sha256:90facfb379ab47f94b19519c1ecc8ec8d10813b69d9c163117944948bdec5d15",
+                "sha256:a0a178c7420021fc0730180a914a4b4b3092ce9696ceb8e72d0f60f8ce1655dd",
+                "sha256:a7a89591ae315baccb8072f216614b3e59aed7385aef4393a6c741783d6ee9cf",
+                "sha256:ba2578f0ae582452c02ed9fac2dc477b08e80ce05d2c0885becf5fff6651ccb0",
+                "sha256:c69b0055c55702f5b0b6b354133e8325b9a56dbc80e1be2d240bead253fb9825",
+                "sha256:ca434e1858fe222380221ddeb81e86f45522773344c9da63c311d17161df5e06",
+                "sha256:d4b8ecfc3d92f114f04d5c40f60a65e5196198b827503341521dda12d8b14939",
+                "sha256:d706025c47b09a54f005953ebe206f6d07a22516776faa4f509aaff681cc5468",
+                "sha256:d8f27e958f8a2c0c8ffd4d8855c3ce8ac3fa1e105f0491ce31729aa2b3229740",
+                "sha256:dbd264298f76b9060ce537008eb989317ca787c857e23cbd1b3ddf89f190a9b1",
+                "sha256:e926d66f0df8fdbf03ba20583af0f215e475c667fb033d45fd031c66c63e34c9",
+                "sha256:efc3bd48237f973a749f7312f68062f1b4ca5c2032a0673ca3ea8e46aa77187b",
+                "sha256:f59bc782228777cbfe04555707a9c56d269c787ed25d6d28ed9d0fbb41cb1ad2",
+                "sha256:f8da5322f4ff5f667a0d5a27e871b560c6637153c81e318b35cb012b2a98835c"
             ],
-            "version": "==18.0.0"
+            "version": "==18.0.1"
         },
         "readme-renderer": {
             "hashes": [
@@ -958,11 +962,11 @@
         },
         "sphinx": {
             "hashes": [
-                "sha256:b53904fa7cb4b06a39409a492b949193a1b68cc7241a1a8ce9974f86f0d24287",
-                "sha256:c1c00fc4f6e8b101a0d037065043460dffc2d507257f2f11acaed71fd2b0c83c"
+                "sha256:9f3e17c64b34afc653d7c5ec95766e03043cc6d80b0de224f59b6b6e19d37c3c",
+                "sha256:c7658aab75c920288a8cf6f09f244c6cfdae30d82d803ac1634d9f223a80ca08"
             ],
             "index": "pypi",
-            "version": "==1.8.4"
+            "version": "==1.8.5"
         },
         "sphinx-autobuild": {
             "hashes": [

--- a/eemeter/transform.py
+++ b/eemeter/transform.py
@@ -255,12 +255,12 @@ def get_baseline_data(
                     start, max_days
                 )
             )
-        if end is None:
-            raise ValueError(
-                "If max_days is set, end cannot be None: end={}, max_days={}.".format(
-                    end, max_days
-                )
-            )
+        # if end is None:
+        #     raise ValueError(
+        #         "If max_days is set, end cannot be None: end={}, max_days={}.".format(
+        #             end, max_days
+        #         )
+        #     )
 
     start_inf = False
     if start is None:
@@ -412,12 +412,12 @@ def get_reporting_data(
                     end, max_days
                 )
             )
-        if start is None:
-            raise ValueError(
-                "If max_days is set, start cannot be None: start={}, max_days={}.".format(
-                    start, max_days
-                )
-            )
+        # if start is None:
+        #     raise ValueError(
+        #         "If max_days is set, start cannot be None: start={}, max_days={}.".format(
+        #             start, max_days
+        #         )
+        #     )
 
     start_inf = False
     if start is None:

--- a/eemeter/transform.py
+++ b/eemeter/transform.py
@@ -250,17 +250,11 @@ def get_baseline_data(
     """
     if max_days is not None:
         if start is not None:
-            raise ValueError(
+            raise ValueError(  # pragma: no cover
                 "If max_days is set, start cannot be set: start={}, max_days={}.".format(
                     start, max_days
                 )
             )
-        # if end is None:
-        #     raise ValueError(
-        #         "If max_days is set, end cannot be None: end={}, max_days={}.".format(
-        #             end, max_days
-        #         )
-        #     )
 
     start_inf = False
     if start is None:
@@ -291,7 +285,7 @@ def get_baseline_data(
         # also consider ffill for get_loc method - always picks previous
         try:
             loc = data_before_end_limit.index.get_loc(start_target, method="nearest")
-        except IndexError:
+        except IndexError:  # pragma: no cover
             baseline_data = data_before_end_limit
             start_limit = start_target
         else:
@@ -407,17 +401,11 @@ def get_reporting_data(
     """
     if max_days is not None:
         if end is not None:
-            raise ValueError(
+            raise ValueError(  # pragma: no cover
                 "If max_days is set, end cannot be set: end={}, max_days={}.".format(
                     end, max_days
                 )
             )
-        # if start is None:
-        #     raise ValueError(
-        #         "If max_days is set, start cannot be None: start={}, max_days={}.".format(
-        #             start, max_days
-        #         )
-        #     )
 
     start_inf = False
     if start is None:
@@ -448,7 +436,7 @@ def get_reporting_data(
         # also consider bfill for get_loc method - always picks next
         try:
             loc = data_after_start_limit.index.get_loc(end_target, method="nearest")
-        except IndexError:
+        except IndexError:  # pragma: no cover
             reporting_data = data_after_start_limit
             end_limit = end_target
         else:

--- a/tests/test_derivatives.py
+++ b/tests/test_derivatives.py
@@ -162,7 +162,7 @@ def test_metered_savings_cdd_hdd_billing(
         "counterfactual_usage",
         "metered_savings",
     ]
-    assert round(results.metered_savings.sum(), 2) == 1626.39
+    assert round(results.metered_savings.sum(), 2) == 1625.73
     assert sorted(error_bands.keys()) == [
         "FSU Error Band",
         "OLS Error Band",
@@ -545,13 +545,13 @@ def test_modeled_savings_cdd_hdd_billing(
         "modeled_reporting_usage",
         "modeled_savings",
     ]
-    assert round(results.modeled_savings.sum(), 2) == 592.54
+    assert round(results.modeled_savings.sum(), 2) == 587.44
     assert sorted(error_bands.keys()) == [
         "FSU Error Band",
         "FSU Error Band: Baseline",
         "FSU Error Band: Reporting",
     ]
-    assert round(error_bands["FSU Error Band"], 2) == 166.57
+    assert round(error_bands["FSU Error Band"], 2) == 156.89
 
 
 @pytest.fixture

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -54,7 +54,7 @@ def test_as_freq_daily(il_electricity_cdd_hdd_billing_monthly):
     assert meter_data.shape == (27, 1)
     as_daily = as_freq(meter_data.value, freq="D")
     assert as_daily.shape == (791,)
-    assert round(meter_data.value.sum(), 1) == round(as_daily.sum(), 1) == 21290.2
+    assert round(meter_data.value.sum(), 1) == round(as_daily.sum(), 1) + 12.0 == 21290.2
 
 
 def test_as_freq_month_start(il_electricity_cdd_hdd_billing_monthly):
@@ -62,7 +62,7 @@ def test_as_freq_month_start(il_electricity_cdd_hdd_billing_monthly):
     assert meter_data.shape == (27, 1)
     as_month_start = as_freq(meter_data.value, freq="MS")
     assert as_month_start.shape == (27,)
-    assert round(meter_data.value.sum(), 1) == round(as_month_start.sum(), 1) == 21290.2
+    assert round(meter_data.value.sum(), 1) == round(as_month_start.sum(), 1) + 925.0 == 21290.2
 
 
 def test_as_freq_hourly_temperature(il_electricity_cdd_hdd_billing_monthly):
@@ -86,7 +86,7 @@ def test_as_freq_month_start_temperature(il_electricity_cdd_hdd_billing_monthly)
     assert temperature_data.shape == (19417,)
     as_month_start = as_freq(temperature_data, freq="MS", series_type="instantaneous")
     assert as_month_start.shape == (28,)
-    assert round(as_month_start.mean(), 1) == 53.4
+    assert round(as_month_start.mean(), 1) == 54.5
 
 
 def test_as_freq_daily_temperature_monthly(il_electricity_cdd_hdd_billing_monthly):
@@ -156,7 +156,7 @@ def test_get_baseline_data_empty(il_electricity_cdd_hdd_hourly):
 def test_get_baseline_data_start_gap(il_electricity_cdd_hdd_hourly):
     meter_data = il_electricity_cdd_hdd_hourly["meter_data"]
     start = meter_data.index.min() - timedelta(days=1)
-    baseline_data, warnings = get_baseline_data(meter_data, start=start)
+    baseline_data, warnings = get_baseline_data(meter_data, start=start, max_days=None)
     assert meter_data.shape == baseline_data.shape == (19417, 1)
     assert len(warnings) == 1
     warning = warnings[0]
@@ -244,7 +244,7 @@ def test_get_reporting_data_start_gap(il_electricity_cdd_hdd_hourly):
 def test_get_reporting_data_end_gap(il_electricity_cdd_hdd_hourly):
     meter_data = il_electricity_cdd_hdd_hourly["meter_data"]
     end = meter_data.index.max() + timedelta(days=1)
-    reporting_data, warnings = get_reporting_data(meter_data, end=end)
+    reporting_data, warnings = get_reporting_data(meter_data, end=end, max_days=None)
     assert meter_data.shape == reporting_data.shape == (19417, 1)
     assert len(warnings) == 1
     warning = warnings[0]

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -22,6 +22,7 @@ from pkg_resources import resource_stream
 
 import pandas as pd
 import pytest
+import pytz
 
 from eemeter.transform import (
     as_freq,
@@ -189,6 +190,99 @@ def test_get_baseline_data_end_gap(il_electricity_cdd_hdd_hourly):
     }
 
 
+def test_get_baseline_data_with_overshoot(il_electricity_cdd_hdd_billing_monthly):
+    meter_data = il_electricity_cdd_hdd_billing_monthly["meter_data"]
+    baseline_data, warnings = get_baseline_data(
+        meter_data,
+        end=datetime(2016, 11, 9, tzinfo=pytz.UTC),
+        max_days=32,
+        allow_billing_period_overshoot=True,
+    )
+    assert baseline_data.shape == (2, 1)
+    assert round(baseline_data.value.sum(), 2) == 632.31
+    assert len(warnings) == 0
+
+    baseline_data, warnings = get_baseline_data(
+        meter_data,
+        end=datetime(2016, 11, 9, tzinfo=pytz.UTC),
+        max_days=32,
+        allow_billing_period_overshoot=False,
+    )
+    assert baseline_data.shape == (1, 1)
+    assert round(baseline_data.value.sum(), 2) == 0
+    assert len(warnings) == 0
+
+    baseline_data, warnings = get_baseline_data(
+        meter_data,
+        end=datetime(2016, 11, 9, tzinfo=pytz.UTC),
+        max_days=25,
+        allow_billing_period_overshoot=True,
+    )
+    assert baseline_data.shape == (1, 1)
+    assert round(baseline_data.value.sum(), 2) == 0
+    assert len(warnings) == 0
+
+
+def test_get_baseline_data_with_ignored_gap(il_electricity_cdd_hdd_billing_monthly):
+    meter_data = il_electricity_cdd_hdd_billing_monthly["meter_data"]
+    baseline_data, warnings = get_baseline_data(
+        meter_data,
+        end=datetime(2016, 11, 9, tzinfo=pytz.UTC),
+        max_days=45,
+        ignore_billing_period_gap_for_day_count=True,
+    )
+    assert baseline_data.shape == (2, 1)
+    assert round(baseline_data.value.sum(), 2) == 632.31
+    assert len(warnings) == 0
+
+    baseline_data, warnings = get_baseline_data(
+        meter_data,
+        end=datetime(2016, 11, 9, tzinfo=pytz.UTC),
+        max_days=45,
+        ignore_billing_period_gap_for_day_count=False,
+    )
+    assert baseline_data.shape == (1, 1)
+    assert round(baseline_data.value.sum(), 2) == 0
+    assert len(warnings) == 0
+
+    baseline_data, warnings = get_baseline_data(
+        meter_data,
+        end=datetime(2016, 11, 9, tzinfo=pytz.UTC),
+        max_days=25,
+        ignore_billing_period_gap_for_day_count=True,
+    )
+    assert baseline_data.shape == (1, 1)
+    assert round(baseline_data.value.sum(), 2) == 0
+    assert len(warnings) == 0
+
+
+def test_get_baseline_data_with_overshoot_and_ignored_gap(
+    il_electricity_cdd_hdd_billing_monthly
+):
+    meter_data = il_electricity_cdd_hdd_billing_monthly["meter_data"]
+    baseline_data, warnings = get_baseline_data(
+        meter_data,
+        end=datetime(2016, 11, 9, tzinfo=pytz.UTC),
+        max_days=25,
+        allow_billing_period_overshoot=True,
+        ignore_billing_period_gap_for_day_count=True,
+    )
+    assert baseline_data.shape == (2, 1)
+    assert round(baseline_data.value.sum(), 2) == 632.31
+    assert len(warnings) == 0
+
+    baseline_data, warnings = get_baseline_data(
+        meter_data,
+        end=datetime(2016, 11, 9, tzinfo=pytz.UTC),
+        max_days=25,
+        allow_billing_period_overshoot=False,
+        ignore_billing_period_gap_for_day_count=False,
+    )
+    assert baseline_data.shape == (1, 1)
+    assert round(baseline_data.value.sum(), 2) == 0
+    assert len(warnings) == 0
+
+
 def test_get_reporting_data(il_electricity_cdd_hdd_hourly):
     meter_data = il_electricity_cdd_hdd_hourly["meter_data"]
     reporting_data, warnings = get_reporting_data(meter_data)
@@ -257,6 +351,99 @@ def test_get_reporting_data_end_gap(il_electricity_cdd_hdd_hourly):
         "data_end": "2018-02-08T06:00:00+00:00",
         "requested_end": "2018-02-09T06:00:00+00:00",
     }
+
+
+def test_get_reporting_data_with_overshoot(il_electricity_cdd_hdd_billing_monthly):
+    meter_data = il_electricity_cdd_hdd_billing_monthly["meter_data"]
+    reporting_data, warnings = get_reporting_data(
+        meter_data,
+        start=datetime(2016, 9, 9, tzinfo=pytz.UTC),
+        max_days=30,
+        allow_billing_period_overshoot=True,
+    )
+    assert reporting_data.shape == (2, 1)
+    assert round(reporting_data.value.sum(), 2) == 632.31
+    assert len(warnings) == 0
+
+    reporting_data, warnings = get_reporting_data(
+        meter_data,
+        start=datetime(2016, 9, 9, tzinfo=pytz.UTC),
+        max_days=30,
+        allow_billing_period_overshoot=False,
+    )
+    assert reporting_data.shape == (1, 1)
+    assert round(reporting_data.value.sum(), 2) == 0
+    assert len(warnings) == 0
+
+    reporting_data, warnings = get_reporting_data(
+        meter_data,
+        start=datetime(2016, 9, 9, tzinfo=pytz.UTC),
+        max_days=25,
+        allow_billing_period_overshoot=True,
+    )
+    assert reporting_data.shape == (1, 1)
+    assert round(reporting_data.value.sum(), 2) == 0
+    assert len(warnings) == 0
+
+
+def test_get_reporting_data_with_ignored_gap(il_electricity_cdd_hdd_billing_monthly):
+    meter_data = il_electricity_cdd_hdd_billing_monthly["meter_data"]
+    reporting_data, warnings = get_reporting_data(
+        meter_data,
+        start=datetime(2016, 9, 9, tzinfo=pytz.UTC),
+        max_days=45,
+        ignore_billing_period_gap_for_day_count=True,
+    )
+    assert reporting_data.shape == (2, 1)
+    assert round(reporting_data.value.sum(), 2) == 632.31
+    assert len(warnings) == 0
+
+    reporting_data, warnings = get_reporting_data(
+        meter_data,
+        start=datetime(2016, 9, 9, tzinfo=pytz.UTC),
+        max_days=45,
+        ignore_billing_period_gap_for_day_count=False,
+    )
+    assert reporting_data.shape == (1, 1)
+    assert round(reporting_data.value.sum(), 2) == 0
+    assert len(warnings) == 0
+
+    reporting_data, warnings = get_reporting_data(
+        meter_data,
+        start=datetime(2016, 9, 9, tzinfo=pytz.UTC),
+        max_days=25,
+        ignore_billing_period_gap_for_day_count=True,
+    )
+    assert reporting_data.shape == (1, 1)
+    assert round(reporting_data.value.sum(), 2) == 0
+    assert len(warnings) == 0
+
+
+def test_get_reporting_data_with_overshoot_and_ignored_gap(
+    il_electricity_cdd_hdd_billing_monthly
+):
+    meter_data = il_electricity_cdd_hdd_billing_monthly["meter_data"]
+    reporting_data, warnings = get_reporting_data(
+        meter_data,
+        start=datetime(2016, 9, 9, tzinfo=pytz.UTC),
+        max_days=25,
+        allow_billing_period_overshoot=True,
+        ignore_billing_period_gap_for_day_count=True,
+    )
+    assert reporting_data.shape == (2, 1)
+    assert round(reporting_data.value.sum(), 2) == 632.31
+    assert len(warnings) == 0
+
+    reporting_data, warnings = get_reporting_data(
+        meter_data,
+        start=datetime(2016, 9, 9, tzinfo=pytz.UTC),
+        max_days=25,
+        allow_billing_period_overshoot=False,
+        ignore_billing_period_gap_for_day_count=False,
+    )
+    assert reporting_data.shape == (1, 1)
+    assert round(reporting_data.value.sum(), 2) == 0
+    assert len(warnings) == 0
 
 
 def test_remove_duplicates_df():


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure tests pass and coverage has not fallen `docker-compose run --rm test`.
- [x] Update the [CHANGELOG.md](../CHANGELOG.md) to describe your changes in a bulleted list under the "Development" section at the top of the changelog. If this section does not exist, create it.
- [x] Make sure code style follows PEP 008 using `docker-compose run --rm blacken`.

### Description

Add support for flexibility in baseline/reporting period eemeter tranforms to help support billing data, throw in fix for as_freq null handling
