### PR TITLE
Fix as_freq last value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Changelog
 Development
 -----------
 
-* Placeholder
+* Fix `as_freq` behavior to preserve sum and add a null last index at the target
+  frequency if necessary.
 
 2.5.1
 -----

--- a/eemeter/transform.py
+++ b/eemeter/transform.py
@@ -127,7 +127,14 @@ def as_freq(data_series, freq, atomic_freq="1 Min", series_type="cumulative"):
         atomic_series = series.asfreq(atomic_freq, method="ffill")
         resampled = atomic_series.resample(freq).mean()
 
-    resampled.iloc[-1] = np.nan
+    if resampled.index[-1] < series.index[-1]:
+        # this adds a null at the end using the target frequency
+        last_index = pd.date_range(resampled.index[-1], freq=freq, periods=2)[1:]
+        resampled = (
+            pd.concat([resampled, pd.Series(np.nan, index=last_index)])
+            .resample(freq)
+            .mean()
+        )
     return resampled
 
 

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -54,22 +54,16 @@ def test_as_freq_daily(il_electricity_cdd_hdd_billing_monthly):
     meter_data = il_electricity_cdd_hdd_billing_monthly["meter_data"]
     assert meter_data.shape == (27, 1)
     as_daily = as_freq(meter_data.value, freq="D")
-    assert as_daily.shape == (791,)
-    assert (
-        round(meter_data.value.sum(), 1) == round(as_daily.sum(), 1) + 12.0 == 21290.2
-    )
+    assert as_daily.shape == (792,)
+    assert round(meter_data.value.sum(), 1) == round(as_daily.sum(), 1) == 21290.2
 
 
 def test_as_freq_month_start(il_electricity_cdd_hdd_billing_monthly):
     meter_data = il_electricity_cdd_hdd_billing_monthly["meter_data"]
     assert meter_data.shape == (27, 1)
     as_month_start = as_freq(meter_data.value, freq="MS")
-    assert as_month_start.shape == (27,)
-    assert (
-        round(meter_data.value.sum(), 1)
-        == round(as_month_start.sum(), 1) + 925.0
-        == 21290.2
-    )
+    assert as_month_start.shape == (28,)
+    assert round(meter_data.value.sum(), 1) == round(as_month_start.sum(), 1) == 21290.2
 
 
 def test_as_freq_hourly_temperature(il_electricity_cdd_hdd_billing_monthly):
@@ -84,7 +78,7 @@ def test_as_freq_daily_temperature(il_electricity_cdd_hdd_billing_monthly):
     temperature_data = il_electricity_cdd_hdd_billing_monthly["temperature_data"]
     assert temperature_data.shape == (19417,)
     as_daily = as_freq(temperature_data, freq="D", series_type="instantaneous")
-    assert as_daily.shape == (810,)
+    assert as_daily.shape == (811,)
     assert abs(temperature_data.mean() - as_daily.mean()) <= 0.1
 
 
@@ -92,8 +86,8 @@ def test_as_freq_month_start_temperature(il_electricity_cdd_hdd_billing_monthly)
     temperature_data = il_electricity_cdd_hdd_billing_monthly["temperature_data"]
     assert temperature_data.shape == (19417,)
     as_month_start = as_freq(temperature_data, freq="MS", series_type="instantaneous")
-    assert as_month_start.shape == (28,)
-    assert round(as_month_start.mean(), 1) == 54.5
+    assert as_month_start.shape == (29,)
+    assert round(as_month_start.mean(), 1) == 53.4
 
 
 def test_as_freq_daily_temperature_monthly(il_electricity_cdd_hdd_billing_monthly):
@@ -109,6 +103,21 @@ def test_as_freq_empty():
     meter_data = pd.DataFrame({"value": []})
     empty_meter_data = as_freq(meter_data.value, freq="H")
     assert empty_meter_data.empty
+
+
+def test_as_freq_perserves_nulls(il_electricity_cdd_hdd_billing_monthly):
+    meter_data = il_electricity_cdd_hdd_billing_monthly["meter_data"]
+    monthly_with_nulls = meter_data[meter_data.index.year != 2016].reindex(
+        meter_data.index
+    )
+    daily_with_nulls = as_freq(monthly_with_nulls.value, freq="D")
+    assert (
+        round(monthly_with_nulls.value.sum(), 2)
+        == round(daily_with_nulls.sum(), 2)
+        == 11094.05
+    )
+    assert monthly_with_nulls.value.isnull().sum() == 13
+    assert daily_with_nulls.isnull().sum() == 365
 
 
 def test_day_counts(il_electricity_cdd_hdd_billing_monthly):


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side). Don't request your master!
- [ ] Make sure tests pass and coverage has not fallen `docker-compose run --rm test`.
- [x] Update the [CHANGELOG.md](../CHANGELOG.md) to describe your changes in a bulleted list under the "Development" section at the top of the changelog. If this section does not exist, create it.
- [x] Make sure code style follows PEP 008 using `docker-compose run --rm blacken`.

### Description

Fix `as_freq` behavior to preserve sum and add a null last index at the target frequency if necessary..
