### PR TITLE
Update so no error band is calculated when there is no baseline variance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 Development
 -----------
 
-* Fix `metered_savings` behavior so that it does not fail to compute error bands when there is 0 variance in the baseline.
+* Fix the `metered_savings` behavior so that it does not fail to compute error bands when there is 0 variance in the baseline.
 
 2.5.2
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 Development
 -----------
 
-* Placeholder
+* Fix `metered_savings` behavior so that it does not fail to compute error bands when there is 0 variance in the baseline.
 
 2.5.2
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 Development
 -----------
 
-* Fix the `metered_savings` behavior so that it does not fail to compute error bands when there is 0 variance in the baseline.
+* Fix `metered_savings` behavior so that it does not fail to compute error bands when there is 0 variance in the baseline.
 
 2.5.2
 -----

--- a/eemeter/derivatives.py
+++ b/eemeter/derivatives.py
@@ -94,6 +94,7 @@ def _compute_error_bands_metered_savings(
         or abs(autocorr_resid) == 1
         or base_obs == 0
         or base_avg == 0
+        or base_var == 0
     ):
         return None
 

--- a/tests/test_derivatives.py
+++ b/tests/test_derivatives.py
@@ -229,14 +229,16 @@ def baseline_model_billing_single_record_baseline_data(
 
 def test_metered_savings_cdd_hdd_billing_single_record_baseline_data(
     baseline_model_billing_single_record_baseline_data,
-    reporting_meter_data_billing, reporting_temperature_data
+    reporting_meter_data_billing,
+    reporting_temperature_data,
 ):
 
     results, error_bands = metered_savings(
         baseline_model_billing_single_record_baseline_data,
-        reporting_meter_data_billing, reporting_temperature_data
+        reporting_meter_data_billing,
+        reporting_temperature_data,
     )
-    '''
+    """
     assert list(results.columns) == [
         "reporting_observed",
         "counterfactual_usage",
@@ -249,8 +251,7 @@ def test_metered_savings_cdd_hdd_billing_single_record_baseline_data(
         "OLS Error Band: Model Error",
         "OLS Error Band: Noise",
     ]
-    '''
-
+    """
 
 
 @pytest.fixture


### PR DESCRIPTION


### Your checklist for this pull request

Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure tests pass and coverage has not fallen `docker-compose run --rm test`.
- [x] Update the [CHANGELOG.md](../CHANGELOG.md) to describe your changes in a bulleted list under the "Development" section at the top of the changelog. If this section does not exist, create it.
- [x] Make sure code style follows PEP 008 using `docker-compose run --rm blacken`.

### Description

Update so no error band is calculated when there is no baseline variance
