### PR TITLE
Feature/add term lengths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changelog
 Development
 -----------
 
+* Add `get_terms` method to allow splitting reporting data into any number
+  of terms specified by day length.
 * Change `fit_caltrack_hourly_model` so it returns a `CalTRACKHourlyModelResults` object rather than a `CalTRACKHourlyModel`, in order to bring it in line with the `caltrack_usage_per_day` model outputs.
 
 2.5.4-post1

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -4,7 +4,7 @@ Advanced Usage
 CalTRACK method options
 -----------------------
 
-TODO. For now, see :any:`eemeter.caltrack_method` for full set of options.
+TODO. For now, see :ref:`caltrack` for full set of options.
 
 CalTRACK Data Sufficiency Criteria
 ----------------------------------
@@ -21,16 +21,16 @@ The eemeter library is the reference implementation of the CalTRACK methods,
 but it is *not* the CalTRACK methods. CalTRACK refers to the methods
 themselves, for which the documentation is not kept in this repository.
 The most current information about methods and proposed changes can be found
-on `github <https://github.com/CalTRACK-2/caltrack/>`_.
+on `github <https://github.com/energy-market-methods/caltrack/>`_.
 
 How the models work
 ///////////////////
 
 We're planning a deeper dive on the methods here, but for now, see
 `openee.io <https://www.openee.io/open-source/how-it-works>`_, dig into
-the :any:`code <eemeter.caltrack_method>` (try viewing the source link),
-or try :any:`visualizing <eemeter.ModelResults.plot>` some the models built with
-the sample data.
+the :ref:`caltrack` (try viewing the source link),
+or try :any:`visualizing <eemeter.CalTRACKUsagePerDayModelResults.plot>` some
+the models built with the sample data.
 
 
 For developers

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,6 +1,7 @@
 API Docs
 ========
 
+.. _caltrack:
 
 CalTRACK
 --------
@@ -184,6 +185,8 @@ Transformation utilities
 .. autofunction:: eemeter.get_baseline_data
 
 .. autofunction:: eemeter.get_reporting_data
+
+.. autofunction:: eemeter.get_terms
 
 .. autofunction:: eemeter.remove_duplicates
 

--- a/eemeter/caltrack/usage_per_day.py
+++ b/eemeter/caltrack/usage_per_day.py
@@ -2011,8 +2011,8 @@ def caltrack_sufficiency_criteria(
     n_valid_days = int((valid_rows * row_day_counts).sum())
 
     median = data_quality.meter_value.median()
-    upper_quantile = data_quality.meter_value.quantile(.75)
-    lower_quantile = data_quality.meter_value.quantile(.25)
+    upper_quantile = data_quality.meter_value.quantile(0.75)
+    lower_quantile = data_quality.meter_value.quantile(0.25)
     iqr = upper_quantile - lower_quantile
     extreme_value_limit = median + (3 * iqr)
     n_extreme_values = data_quality.meter_value[

--- a/eemeter/transform.py
+++ b/eemeter/transform.py
@@ -472,13 +472,7 @@ def get_reporting_data(
     )
 
 
-def get_terms(
-    index,
-    term_lengths,
-    term_labels=None,
-    start=None,
-    method='strict',
-):
+def get_terms(index, term_lengths, term_labels=None, start=None, method="strict"):
     """ Label a time series index with terms.
 
     Parameters
@@ -514,20 +508,22 @@ def get_terms(
         get_loc_method = "nearest"
     else:
         raise ValueError(
-            "method {} not supported - use either 'strict' or 'closest'"
-            .format(method)
+            "method {} not supported - use either 'strict' or 'closest'".format(method)
         )
 
     if not index.is_monotonic_increasing:
         raise ValueError("get_terms requires a sorted index")
 
     if term_labels is None:
-        term_labels = ['term_{:03d}'.format(i + 1) for i, term_length in enumerate(term_lengths)]
+        term_labels = [
+            "term_{:03d}".format(i + 1) for i, term_length in enumerate(term_lengths)
+        ]
 
     elif len(term_labels) != len(term_lengths):
         raise ValueError(
-            "term_labels (len {}) must be the same length as term_length (len {})"
-            .format(len(term_labels), len(term_lengths))
+            "term_labels (len {}) must be the same length as term_length (len {})".format(
+                len(term_labels), len(term_lengths)
+            )
         )
 
     if start is None:
@@ -536,7 +532,7 @@ def get_terms(
         prev_start = start
 
     term_end_targets = [
-        prev_start + timedelta(days=sum(term_lengths[:i+1]))
+        prev_start + timedelta(days=sum(term_lengths[: i + 1]))
         for i in range(len(term_lengths))
     ]
 

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -558,16 +558,6 @@ def test_get_terms_nearest(il_electricity_cdd_hdd_billing_monthly):
     assert year2.index[-1] == pd.Timestamp('2017-12-22 06:00:00+00:00', tz='UTC')
 
 
-def test_get_terms_strict(il_electricity_cdd_hdd_billing_monthly):
-    meter_data = il_electricity_cdd_hdd_billing_monthly["meter_data"]
-
-    terms = get_terms(
-        meter_data.index,
-        term_lengths=[365, 365],
-        term_labels=["year1", "year2"],
-    )
-
-
 def test_remove_duplicates_df():
     index = pd.DatetimeIndex(["2017-01-01", "2017-01-02", "2017-01-02"])
     df = pd.DataFrame({"value": [1, 2, 3]}, index=index)

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -29,6 +29,7 @@ from eemeter.transform import (
     day_counts,
     get_baseline_data,
     get_reporting_data,
+    get_terms,
     remove_duplicates,
     NoBaselineDataError,
     NoReportingDataError,
@@ -459,6 +460,112 @@ def test_get_reporting_data_with_overshoot_and_ignored_gap(
     assert reporting_data.shape == (1, 1)
     assert round(reporting_data.value.sum(), 2) == 0
     assert len(warnings) == 0
+
+
+def test_get_terms_unrecognized_method(il_electricity_cdd_hdd_billing_monthly):
+    meter_data = il_electricity_cdd_hdd_billing_monthly["meter_data"]
+
+    with pytest.raises(ValueError):
+        get_terms(meter_data.index, term_lengths=[365], method="unrecognized")
+
+
+def test_get_terms_unsorted_index(il_electricity_cdd_hdd_billing_monthly):
+    meter_data = il_electricity_cdd_hdd_billing_monthly["meter_data"]
+
+    with pytest.raises(ValueError):
+        get_terms(meter_data.index[::-1], term_lengths=[365])
+
+
+def test_get_terms_bad_term_labels(il_electricity_cdd_hdd_billing_monthly):
+    meter_data = il_electricity_cdd_hdd_billing_monthly["meter_data"]
+
+    with pytest.raises(ValueError):
+        terms = get_terms(
+            meter_data.index,
+            term_lengths=[60, 60, 60],
+            term_labels=['abc', 'def'],  # too short
+        )
+
+
+def test_get_terms_default_term_labels(il_electricity_cdd_hdd_billing_monthly):
+    meter_data = il_electricity_cdd_hdd_billing_monthly["meter_data"]
+
+    terms = get_terms(meter_data.index, term_lengths=[60, 60, 60])
+    assert set(terms) == {None, 'term_001', 'term_003', 'term_002'}
+
+
+def test_get_terms_custom_term_labels(il_electricity_cdd_hdd_billing_monthly):
+    meter_data = il_electricity_cdd_hdd_billing_monthly["meter_data"]
+
+    terms = get_terms(
+        meter_data.index,
+        term_lengths=[60, 60, 60],
+        term_labels=['abc', 'def', 'ghi']
+    )
+    assert set(terms) == {None, 'abc', 'def', 'ghi'}
+
+
+def test_get_terms_empty_index_input(il_electricity_cdd_hdd_billing_monthly):
+    meter_data = il_electricity_cdd_hdd_billing_monthly["meter_data"]
+
+    terms = get_terms(
+        meter_data.index[:0],
+        term_lengths=[60, 60, 60],
+    )
+    assert terms.empty
+
+
+def test_get_terms_strict(il_electricity_cdd_hdd_billing_monthly):
+    meter_data = il_electricity_cdd_hdd_billing_monthly["meter_data"]
+
+    strict_terms = get_terms(
+        meter_data.index,
+        term_lengths=[365, 365],
+        term_labels=["year1", "year2"],
+        start=datetime(2016, 1, 15, tzinfo=pytz.UTC),
+        method="strict",
+    )
+
+    year1 = strict_terms[strict_terms == 'year1']
+    assert year1.shape == (11,)
+    assert year1.index[0] == pd.Timestamp('2016-01-22 06:00:00+0000', tz='UTC')
+    assert year1.index[-1] == pd.Timestamp('2016-11-23 06:00:00+0000', tz='UTC')
+
+    year2 = strict_terms[strict_terms == 'year2']
+    assert year2.shape == (12,)
+    assert year2.index[0] == pd.Timestamp('2016-12-19 06:00:00+00:00', tz='UTC')
+    assert year2.index[-1] == pd.Timestamp('2017-11-25 06:00:00+00:00', tz='UTC')
+
+
+def test_get_terms_nearest(il_electricity_cdd_hdd_billing_monthly):
+    meter_data = il_electricity_cdd_hdd_billing_monthly["meter_data"]
+    nearest_terms = get_terms(
+        meter_data.index,
+        term_lengths=[365, 365],
+        term_labels=["year1", "year2"],
+        start=datetime(2016, 1, 15, tzinfo=pytz.UTC),
+        method="nearest",
+    )
+
+    year1 = nearest_terms[nearest_terms == 'year1']
+    assert year1.shape == (12,)
+    assert year1.index[0] == pd.Timestamp('2016-01-22 06:00:00+0000', tz='UTC')
+    assert year1.index[-1] == pd.Timestamp('2016-12-19 06:00:00+0000', tz='UTC')
+
+    year2 = nearest_terms[nearest_terms == 'year2']
+    assert year2.shape == (12,)
+    assert year2.index[0] == pd.Timestamp('2017-01-21 06:00:00+00:00', tz='UTC')
+    assert year2.index[-1] == pd.Timestamp('2017-12-22 06:00:00+00:00', tz='UTC')
+
+
+def test_get_terms_strict(il_electricity_cdd_hdd_billing_monthly):
+    meter_data = il_electricity_cdd_hdd_billing_monthly["meter_data"]
+
+    terms = get_terms(
+        meter_data.index,
+        term_lengths=[365, 365],
+        term_labels=["year1", "year2"],
+    )
 
 
 def test_remove_duplicates_df():


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure tests pass and coverage has not fallen `docker-compose run --rm test`.
- [x] Update the [CHANGELOG.md](../CHANGELOG.md) to describe your changes in a bulleted list under the "Development" section at the top of the changelog. If this section does not exist, create it.
- [x] Make sure code style follows PEP 008 using `docker-compose run --rm blacken`.
- [x] Make sure that new functions and classes have inline docstrings and are
  included in [docs/api.rst](../docs/api.rst) for the sphinx build. Please use [numpy-style docstrings](https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html#google-vs-numpy).
  Sphinx docs can be built with the following command: `docker-compose run --rm --entrypoint="make -C docs html" shell`. Please note and fix any warnings.
- [x] Make sure that all git commits are have the "Signed-off-by" message for
  the Developer Certificate of Origin. When you're making a commit, just add
  the `-s/--signoff` flag (e.g., `git commit -s`).

### Description

Adds a get_terms method which labels a time series index with terms. This can be used to separate a reporting period into consecutive terms - an operation which would otherwise be a bit ambiguous.
