### PR TITLE
Add test for empty prediction with design matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changelog
 Development
 -----------
 
+* Fixes the columns that are given in an empty prediction result called with the
+  ` with_design_matrix=True` flag set for caltrack usage per day methods.
 * Update bug report github issue template.
 * Add test for `as_freq`.
 

--- a/eemeter/caltrack/usage_per_day.py
+++ b/eemeter/caltrack/usage_per_day.py
@@ -659,6 +659,15 @@ def caltrack_usage_per_day_predict(
         use_mean_daily_values=False,
     )
 
+    if degree_day_method == "daily":
+        design_matrix["n_days"] = (
+            design_matrix.n_days_kept + design_matrix.n_days_dropped
+        )
+    else:
+        design_matrix["n_days"] = (
+            design_matrix.n_hours_kept + design_matrix.n_hours_dropped
+        ) / 24
+
     if design_matrix.dropna().empty:
         if with_disaggregated:
             empty_columns = {
@@ -669,6 +678,9 @@ def caltrack_usage_per_day_predict(
             }
         else:
             empty_columns = {"predicted_usage": []}
+
+        if with_design_matrix:
+            empty_columns.update({col: [] for col in design_matrix.columns})
 
         predict_warnings.append(
             EEMeterWarning(
@@ -685,15 +697,6 @@ def caltrack_usage_per_day_predict(
             design_matrix=pd.DataFrame(),
             warnings=predict_warnings,
         )
-
-    if degree_day_method == "daily":
-        design_matrix["n_days"] = (
-            design_matrix.n_days_kept + design_matrix.n_days_dropped
-        )
-    else:
-        design_matrix["n_days"] = (
-            design_matrix.n_hours_kept + design_matrix.n_hours_dropped
-        ) / 24
 
     results = _caltrack_predict_design_matrix(
         model_type,

--- a/tests/test_caltrack_usage_per_day.py
+++ b/tests/test_caltrack_usage_per_day.py
@@ -17,13 +17,11 @@
    limitations under the License.
 
 """
-from datetime import datetime
 import json
 
 import numpy as np
 import pandas as pd
 import pytest
-import pytz
 
 from eemeter.caltrack.usage_per_day import (
     CalTRACKUsagePerDayCandidateModel,
@@ -616,8 +614,8 @@ def test_caltrack_predict_cdd_hdd_with_design_matrix_missing_temp_data(
     temp_data = temperature_data["2015-11":"2016-03"]
     temp_data_greater_90perc_missing = temp_data[
         ~(
-            (datetime(2016, 1, 27, 12, tzinfo=pytz.utc) < temp_data.index)
-            & (temp_data.index < datetime(2016, 1, 31, 12, tzinfo=pytz.utc))
+            (pd.Timestamp('2016-01-27T12:00:00', tz='utc') < temp_data.index)
+            & (temp_data.index < pd.Timestamp('2016-01-31T12:00:00', tz='utc'))
         )
     ].reindex(temp_data.index)
 

--- a/tests/test_caltrack_usage_per_day.py
+++ b/tests/test_caltrack_usage_per_day.py
@@ -614,8 +614,8 @@ def test_caltrack_predict_cdd_hdd_with_design_matrix_missing_temp_data(
     temp_data = temperature_data["2015-11":"2016-03"]
     temp_data_greater_90perc_missing = temp_data[
         ~(
-            (pd.Timestamp('2016-01-27T12:00:00', tz='utc') < temp_data.index)
-            & (temp_data.index < pd.Timestamp('2016-01-31T12:00:00', tz='utc'))
+            (pd.Timestamp("2016-01-27T12:00:00", tz="utc") < temp_data.index)
+            & (temp_data.index < pd.Timestamp("2016-01-31T12:00:00", tz="utc"))
         )
     ].reindex(temp_data.index)
 
@@ -2009,7 +2009,7 @@ def test_caltrack_usage_per_day_predict_empty(prediction_index, temperature_data
         "n_days_dropped",
         "n_days_kept",
         "predicted_usage",
-        "temperature_mean"
+        "temperature_mean",
     ]
     assert round(prediction.result.predicted_usage.sum(), 2) == 0
 
@@ -2031,7 +2031,7 @@ def test_caltrack_usage_per_day_temp_empty(prediction_index, temperature_data):
         "n_days_dropped",
         "n_days_kept",
         "predicted_usage",
-        "temperature_mean"
+        "temperature_mean",
     ]
     assert round(prediction.result.predicted_usage.sum(), 2) == 0
     assert prediction.result.predicted_usage.shape[0] == 0

--- a/tests/test_caltrack_usage_per_day.py
+++ b/tests/test_caltrack_usage_per_day.py
@@ -2007,7 +2007,11 @@ def test_caltrack_usage_per_day_predict_empty(prediction_index, temperature_data
         "base_load",
         "cooling_load",
         "heating_load",
+        "n_days",
+        "n_days_dropped",
+        "n_days_kept",
         "predicted_usage",
+        "temperature_mean"
     ]
     assert round(prediction.result.predicted_usage.sum(), 2) == 0
 
@@ -2025,26 +2029,11 @@ def test_caltrack_usage_per_day_temp_empty(prediction_index, temperature_data):
         "base_load",
         "cooling_load",
         "heating_load",
+        "n_days",
+        "n_days_dropped",
+        "n_days_kept",
         "predicted_usage",
-    ]
-    assert round(prediction.result.predicted_usage.sum(), 2) == 0
-    assert prediction.result.predicted_usage.shape[0] == 0
-
-
-def test_caltrack_usage_per_day_temp_empty(prediction_index, temperature_data):
-    prediction = caltrack_usage_per_day_predict(
-        "intercept_only",
-        {"intercept": 1},
-        prediction_index,
-        temperature_data[:0],
-        with_disaggregated=True,
-        with_design_matrix=True,
-    )
-    assert sorted(prediction.result.columns) == [
-        "base_load",
-        "cooling_load",
-        "heating_load",
-        "predicted_usage",
+        "temperature_mean"
     ]
     assert round(prediction.result.predicted_usage.sum(), 2) == 0
     assert prediction.result.predicted_usage.shape[0] == 0

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -907,7 +907,7 @@ def meter_data_billing():
 
 def test_compute_usage_per_day_feature_billing(meter_data_billing):
     usage_per_day = compute_usage_per_day_feature(meter_data_billing)
-    assert usage_per_day["2017-01-01T00:00:00Z"] == 1. / 31
+    assert usage_per_day["2017-01-01T00:00:00Z"] == 1.0 / 31
     assert usage_per_day.sum().round(3) == 3.257
 
 

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -62,17 +62,16 @@ def test_as_freq_daily(il_electricity_cdd_hdd_billing_monthly):
 
 def test_as_freq_daily_all_nones_instantaneous(il_electricity_cdd_hdd_billing_monthly):
     meter_data = il_electricity_cdd_hdd_billing_monthly["meter_data"]
-    meter_data['value'] = np.nan
+    meter_data["value"] = np.nan
     assert meter_data.shape == (27, 1)
     as_daily = as_freq(meter_data.value, freq="D", series_type="instantaneous")
     assert as_daily.shape == (792,)
     assert round(meter_data.value.sum(), 1) == round(as_daily.sum(), 1) == 0
 
 
-
 def test_as_freq_daily_all_nones(il_electricity_cdd_hdd_billing_monthly):
     meter_data = il_electricity_cdd_hdd_billing_monthly["meter_data"]
-    meter_data['value'] = np.nan
+    meter_data["value"] = np.nan
     assert meter_data.shape == (27, 1)
     as_daily = as_freq(meter_data.value, freq="D")
     assert as_daily.shape == (792,)
@@ -503,7 +502,7 @@ def test_get_terms_bad_term_labels(il_electricity_cdd_hdd_billing_monthly):
         terms = get_terms(
             meter_data.index,
             term_lengths=[60, 60, 60],
-            term_labels=['abc', 'def'],  # too short
+            term_labels=["abc", "def"],  # too short
         )
 
 
@@ -511,27 +510,22 @@ def test_get_terms_default_term_labels(il_electricity_cdd_hdd_billing_monthly):
     meter_data = il_electricity_cdd_hdd_billing_monthly["meter_data"]
 
     terms = get_terms(meter_data.index, term_lengths=[60, 60, 60])
-    assert set(terms) == {None, 'term_001', 'term_003', 'term_002'}
+    assert set(terms) == {None, "term_001", "term_003", "term_002"}
 
 
 def test_get_terms_custom_term_labels(il_electricity_cdd_hdd_billing_monthly):
     meter_data = il_electricity_cdd_hdd_billing_monthly["meter_data"]
 
     terms = get_terms(
-        meter_data.index,
-        term_lengths=[60, 60, 60],
-        term_labels=['abc', 'def', 'ghi']
+        meter_data.index, term_lengths=[60, 60, 60], term_labels=["abc", "def", "ghi"]
     )
-    assert set(terms) == {None, 'abc', 'def', 'ghi'}
+    assert set(terms) == {None, "abc", "def", "ghi"}
 
 
 def test_get_terms_empty_index_input(il_electricity_cdd_hdd_billing_monthly):
     meter_data = il_electricity_cdd_hdd_billing_monthly["meter_data"]
 
-    terms = get_terms(
-        meter_data.index[:0],
-        term_lengths=[60, 60, 60],
-    )
+    terms = get_terms(meter_data.index[:0], term_lengths=[60, 60, 60])
     assert terms.empty
 
 
@@ -546,15 +540,15 @@ def test_get_terms_strict(il_electricity_cdd_hdd_billing_monthly):
         method="strict",
     )
 
-    year1 = strict_terms[strict_terms == 'year1']
+    year1 = strict_terms[strict_terms == "year1"]
     assert year1.shape == (11,)
-    assert year1.index[0] == pd.Timestamp('2016-01-22 06:00:00+0000', tz='UTC')
-    assert year1.index[-1] == pd.Timestamp('2016-11-23 06:00:00+0000', tz='UTC')
+    assert year1.index[0] == pd.Timestamp("2016-01-22 06:00:00+0000", tz="UTC")
+    assert year1.index[-1] == pd.Timestamp("2016-11-23 06:00:00+0000", tz="UTC")
 
-    year2 = strict_terms[strict_terms == 'year2']
+    year2 = strict_terms[strict_terms == "year2"]
     assert year2.shape == (12,)
-    assert year2.index[0] == pd.Timestamp('2016-12-19 06:00:00+00:00', tz='UTC')
-    assert year2.index[-1] == pd.Timestamp('2017-11-25 06:00:00+00:00', tz='UTC')
+    assert year2.index[0] == pd.Timestamp("2016-12-19 06:00:00+00:00", tz="UTC")
+    assert year2.index[-1] == pd.Timestamp("2017-11-25 06:00:00+00:00", tz="UTC")
 
 
 def test_get_terms_nearest(il_electricity_cdd_hdd_billing_monthly):
@@ -567,15 +561,15 @@ def test_get_terms_nearest(il_electricity_cdd_hdd_billing_monthly):
         method="nearest",
     )
 
-    year1 = nearest_terms[nearest_terms == 'year1']
+    year1 = nearest_terms[nearest_terms == "year1"]
     assert year1.shape == (12,)
-    assert year1.index[0] == pd.Timestamp('2016-01-22 06:00:00+0000', tz='UTC')
-    assert year1.index[-1] == pd.Timestamp('2016-12-19 06:00:00+0000', tz='UTC')
+    assert year1.index[0] == pd.Timestamp("2016-01-22 06:00:00+0000", tz="UTC")
+    assert year1.index[-1] == pd.Timestamp("2016-12-19 06:00:00+0000", tz="UTC")
 
-    year2 = nearest_terms[nearest_terms == 'year2']
+    year2 = nearest_terms[nearest_terms == "year2"]
     assert year2.shape == (12,)
-    assert year2.index[0] == pd.Timestamp('2017-01-21 06:00:00+00:00', tz='UTC')
-    assert year2.index[-1] == pd.Timestamp('2017-12-22 06:00:00+00:00', tz='UTC')
+    assert year2.index[0] == pd.Timestamp("2017-01-21 06:00:00+00:00", tz="UTC")
+    assert year2.index[-1] == pd.Timestamp("2017-12-22 06:00:00+00:00", tz="UTC")
 
 
 def test_remove_duplicates_df():


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure tests pass and coverage has not fallen `docker-compose run --rm test`.
- [x] Update the [CHANGELOG.md](../CHANGELOG.md) to describe your changes in a bulleted list under the "Development" section at the top of the changelog. If this section does not exist, create it.
- [x] Make sure code style follows PEP 008 using `docker-compose run --rm blacken`.
- [x] Make sure that new functions and classes have inline docstrings and are
  included in [docs/api.rst](../docs/api.rst) for the sphinx build. Please use [numpy-style docstrings](https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html#google-vs-numpy).
  Sphinx docs can be built with the following command: `docker-compose run --rm --entrypoint="make -C docs html" shell`. Please note and fix any warnings.
- [x] Make sure that all git commits are have the "Signed-off-by" message for
  the Developer Certificate of Origin. When you're making a commit, just add
  the `-s/--signoff` flag (e.g., `git commit -s`).

### Description

Fixes the columns that are given in an empty prediction result called with the `with_design_matrix=True` flag set.
