### PR TITLE
More usable output for get_terms function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 Development
 -----------
 
-* Placeholder
+* Make more usable outputs for the `get_terms` function (list of eemeter.Term objects).
 
 2.7.2
 -----

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -186,6 +186,9 @@ Transformation utilities
 
 .. autofunction:: eemeter.get_reporting_data
 
+.. autoclass:: eemeter.Term
+   :members:
+
 .. autofunction:: eemeter.get_terms
 
 .. autofunction:: eemeter.remove_duplicates

--- a/eemeter/transform.py
+++ b/eemeter/transform.py
@@ -640,5 +640,4 @@ def get_terms(index, term_lengths, term_labels=None, start=None, method="strict"
         prev_start = remaining_index[next_index]
         remaining_index = remaining_index[next_index:]
 
-
     return terms

--- a/eemeter/transform.py
+++ b/eemeter/transform.py
@@ -616,10 +616,6 @@ def get_terms(index, term_lengths, term_labels=None, start=None, method="strict"
         # keep one extra index point for the end NaN
         term_index = remaining_index[: next_index + 1]
 
-        # reset the remaining index
-        prev_start = remaining_index[next_index]
-        remaining_index = remaining_index[next_index:]
-
         # There may be a better way to tell if the term is conclusively complete,
         # but the logic here is that if there's more than one remaining point then
         # the term must be complete - since that final point was a worse candidate
@@ -639,5 +635,10 @@ def get_terms(index, term_lengths, term_labels=None, start=None, method="strict"
                 complete=complete,
             )
         )
+
+        # reset the remaining index
+        prev_start = remaining_index[next_index]
+        remaining_index = remaining_index[next_index:]
+
 
     return terms

--- a/eemeter/transform.py
+++ b/eemeter/transform.py
@@ -483,17 +483,17 @@ class Term(object):
         The index of the term. Includes a period at the end meant to be NaN-value.
     label : :any:`str`
         The label for the term.
-    target_start_date : :any:`pd.Timestamp`
+    target_start_date : :any:`pandas.Timestamp` or :any:`datetime.datetime`
         The start date inferred for this term from the start date and target term
         lenths.
-    target_end_date : :any:`pd.Timestamp`
+    target_end_date : :any:`pandas.Timestamp` or :any:`datetime.datetime`
         The end date inferred for this term from the start date and target term
         lenths.
     target_term_length_days : :any:`int`
         The number of days targeted for this term.
-    actual_start_date : :any:`pd.Timestamp`
+    actual_start_date : :any:`pandas.Timestamp`
         The first date in the index.
-    actual_end_date : :any:`pd.Timestamp`
+    actual_end_date : :any:`pandas.Timestamp`
         The last date in the index.
     actual_term_length_days : :any:`int`
         The number of days between the actual start date and actual end date.

--- a/eemeter/transform.py
+++ b/eemeter/transform.py
@@ -29,6 +29,7 @@ from .warnings import EEMeterWarning
 
 
 __all__ = (
+    "Term",
     "as_freq",
     "day_counts",
     "get_baseline_data",
@@ -472,8 +473,73 @@ def get_reporting_data(
     )
 
 
+class Term(object):
+    """
+    The term object represents a subset of an index.
+
+    Attributes
+    ----------
+    index : :any:`pandas.DatetimeIndex`
+        The index of the term. Includes a period at the end meant to be NaN-value.
+    label : :any:`str`
+        The label for the term.
+    target_start_date : :any:`pd.Timestamp`
+        The start date inferred for this term from the start date and target term
+        lenths.
+    target_end_date : :any:`pd.Timestamp`
+        The end date inferred for this term from the start date and target term
+        lenths.
+    target_term_length_days : :any:`int`
+        The number of days targeted for this term.
+    actual_start_date : :any:`pd.Timestamp`
+        The first date in the index.
+    actual_end_date : :any:`pd.Timestamp`
+        The last date in the index.
+    actual_term_length_days : :any:`int`
+        The number of days between the actual start date and actual end date.
+    complete : :any:`bool`
+        True if this term is conclusively complete, such that additional data added
+        to the series would not add more data to this term.
+
+    """
+
+    def __init__(
+        self,
+        index,
+        label,
+        target_start_date,
+        target_end_date,
+        target_term_length_days,
+        actual_start_date,
+        actual_end_date,
+        actual_term_length_days,
+        complete,
+    ):
+        self.index = index
+        self.label = label
+        self.target_start_date = target_start_date
+        self.target_end_date = target_end_date
+        self.target_term_length_days = target_term_length_days
+        self.actual_start_date = actual_start_date
+        self.actual_end_date = actual_end_date
+        self.actual_term_length_days = actual_term_length_days
+        self.complete = complete
+
+    def __repr__(self):
+        return (
+            "Term(label={}, target_term_length_days={}, actual_term_length_days={},"
+            " complete={})"
+        ).format(
+            self.label,
+            self.target_term_length_days,
+            self.actual_term_length_days,
+            self.complete,
+        )
+
+
 def get_terms(index, term_lengths, term_labels=None, start=None, method="strict"):
-    """ Label a time series index with terms.
+    """ Breaks a :any:`pandas.DatetimeIndex` into consecutive terms of specified
+    lengths.
 
     Parameters
     ----------
@@ -495,7 +561,7 @@ def get_terms(index, term_lengths, term_labels=None, start=None, method="strict"
 
     Returns
     -------
-    reporting_data, warnings : :any:`pandas.DataFrame`
+    terms : :any:`list` of :any:`eemeter.Term`
         A dataframe of term labels with the same :any:`pandas.DatetimeIndex`
         given as `index`. This can be used to filter the original data into
         terms of approximately the desired length.
@@ -536,20 +602,42 @@ def get_terms(index, term_lengths, term_labels=None, start=None, method="strict"
         for i in range(len(term_lengths))
     ]
 
-    terms = [None] * len(index[index < prev_start])
+    terms = []
     remaining_index = index[index >= prev_start]
 
-    # copying prevents setting on slice warnings
-
-    for label, end_target in zip(term_labels, term_end_targets):
-        if remaining_index.empty:
-            return pd.Series(terms, index=index, name="term")
+    for label, target_term_length, end_target in zip(
+        term_labels, term_lengths, term_end_targets
+    ):
+        if len(remaining_index) <= 1:
+            break
 
         next_index = remaining_index.get_loc(end_target, method=get_loc_method)
 
-        terms.extend([label] * len(remaining_index[:next_index]))
+        # keep one extra index point for the end NaN
+        term_index = remaining_index[: next_index + 1]
+
+        # reset the remaining index
         prev_start = remaining_index[next_index]
         remaining_index = remaining_index[next_index:]
 
-    terms.extend([None for i in remaining_index])
-    return pd.Series(terms, index=index, name="term")
+        # There may be a better way to tell if the term is conclusively complete,
+        # but the logic here is that if there's more than one remaining point then
+        # the term must be complete - since that final point was a worse candidate
+        # than the one before it which was chosen.
+        complete = len(remaining_index) > 1
+
+        terms.append(
+            Term(
+                index=term_index,
+                label=label,
+                target_start_date=prev_start,
+                target_end_date=end_target,
+                target_term_length_days=target_term_length,
+                actual_start_date=term_index[0],
+                actual_end_date=term_index[-1],
+                actual_term_length_days=(term_index[-1] - term_index[0]).days,
+                complete=complete,
+            )
+        )
+
+    return terms

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -602,6 +602,17 @@ def test_get_terms_nearest(il_electricity_cdd_hdd_billing_monthly):
     assert year2.complete
 
 
+def test_term_repr(il_electricity_cdd_hdd_billing_monthly):
+    meter_data = il_electricity_cdd_hdd_billing_monthly["meter_data"]
+
+    terms = get_terms(meter_data.index, term_lengths=[60, 60, 60])
+    assert repr(terms[0]) == (
+        "Term(label=term_001, target_term_length_days=60, actual_term_length_days=29,"
+        " complete=True)"
+    )
+
+
+
 def test_remove_duplicates_df():
     index = pd.DatetimeIndex(["2017-01-01", "2017-01-02", "2017-01-02"])
     df = pd.DataFrame({"value": [1, 2, 3]}, index=index)

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -543,28 +543,49 @@ def test_get_terms_strict(il_electricity_cdd_hdd_billing_monthly):
     assert len(strict_terms) == 2
 
     year1 = strict_terms[0]
-    assert year1.label == 'year1'
+    assert year1.label == "year1"
     assert year1.index.shape == (12,)
-    assert year1.target_start_date == pd.Timestamp(
-        "2016-01-15 00:00:00+0000", tz="UTC"
-    ).to_pydatetime()
-    assert year1.target_end_date == pd.Timestamp(
-        "2017-01-14 00:00:00+0000", tz="UTC"
-    ).to_pydatetime()
+    assert (
+        year1.target_start_date
+        == pd.Timestamp("2016-01-15 00:00:00+0000", tz="UTC").to_pydatetime()
+    )
+    assert (
+        year1.target_end_date
+        == pd.Timestamp("2017-01-14 00:00:00+0000", tz="UTC").to_pydatetime()
+    )
     assert year1.target_term_length_days == 365
-    assert year1.actual_start_date == year1.index[0] == pd.Timestamp("2016-01-22 06:00:00+0000", tz="UTC")
-    assert year1.actual_end_date == year1.index[-1] == pd.Timestamp("2016-12-19 06:00:00+0000", tz="UTC")
+    assert (
+        year1.actual_start_date
+        == year1.index[0]
+        == pd.Timestamp("2016-01-22 06:00:00+0000", tz="UTC")
+    )
+    assert (
+        year1.actual_end_date
+        == year1.index[-1]
+        == pd.Timestamp("2016-12-19 06:00:00+0000", tz="UTC")
+    )
     assert year1.actual_term_length_days == 332
     assert year1.complete
 
     year2 = strict_terms[1]
     assert year2.index.shape == (13,)
-    assert year2.label == 'year2'
+    assert year2.label == "year2"
     assert year2.target_start_date == pd.Timestamp("2016-12-19 06:00:00+0000", tz="UTC")
-    assert year2.target_end_date == pd.Timestamp("2018-01-14 00:00:00+0000", tz="UTC").to_pydatetime()
+    assert (
+        year2.target_end_date
+        == pd.Timestamp("2018-01-14 00:00:00+0000", tz="UTC").to_pydatetime()
+    )
     assert year2.target_term_length_days == 365
-    assert year2.actual_start_date == year2.index[0] == pd.Timestamp("2016-12-19 06:00:00+00:00", tz="UTC")
-    assert year2.actual_end_date == year2.index[-1] == pd.Timestamp("2017-12-22 06:00:00+0000", tz="UTC")
+    assert (
+        year2.actual_start_date
+        == year2.index[0]
+        == pd.Timestamp("2016-12-19 06:00:00+00:00", tz="UTC")
+    )
+    assert (
+        year2.actual_end_date
+        == year2.index[-1]
+        == pd.Timestamp("2017-12-22 06:00:00+0000", tz="UTC")
+    )
     assert year2.actual_term_length_days == 368
     assert year2.complete
 
@@ -582,17 +603,20 @@ def test_get_terms_nearest(il_electricity_cdd_hdd_billing_monthly):
     assert len(nearest_terms) == 2
 
     year1 = nearest_terms[0]
-    assert year1.label == 'year1'
+    assert year1.label == "year1"
     assert year1.index.shape == (13,)
     assert year1.index[0] == pd.Timestamp("2016-01-22 06:00:00+0000", tz="UTC")
     assert year1.index[-1] == pd.Timestamp("2017-01-21 06:00:00+0000", tz="UTC")
-    assert year1.target_start_date == pd.Timestamp("2016-01-15 00:00:00+0000", tz="UTC").to_pydatetime()
+    assert (
+        year1.target_start_date
+        == pd.Timestamp("2016-01-15 00:00:00+0000", tz="UTC").to_pydatetime()
+    )
     assert year1.target_term_length_days == 365
     assert year1.actual_term_length_days == 365
     assert year1.complete
 
     year2 = nearest_terms[1]
-    assert year2.label == 'year2'
+    assert year2.label == "year2"
     assert year2.index.shape == (13,)
     assert year2.index[0] == pd.Timestamp("2017-01-21 06:00:00+0000", tz="UTC")
     assert year2.index[-1] == pd.Timestamp("2018-01-20 06:00:00+0000", tz="UTC")
@@ -610,7 +634,6 @@ def test_term_repr(il_electricity_cdd_hdd_billing_monthly):
         "Term(label=term_001, target_term_length_days=60, actual_term_length_days=29,"
         " complete=True)"
     )
-
 
 
 def test_remove_duplicates_df():


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure tests pass and coverage has not fallen `docker-compose run --rm test`.
- [x] Update the [CHANGELOG.md](../CHANGELOG.md) to describe your changes in a bulleted list under the "Development" section at the top of the changelog. If this section does not exist, create it.
- [x] Make sure code style follows PEP 008 using `docker-compose run --rm blacken`.
- [x] Make sure that new functions and classes have inline docstrings and are
  included in [docs/api.rst](../docs/api.rst) for the sphinx build. Please use [numpy-style docstrings](https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html#google-vs-numpy).
  Sphinx docs can be built with the following command: `docker-compose run --rm --entrypoint="make -C docs html" shell`. Please note and fix any warnings.
- [x] Make sure that all git commits are have the "Signed-off-by" message for
  the Developer Certificate of Origin. When you're making a commit, just add
  the `-s/--signoff` flag (e.g., `git commit -s`).

### Description

More usable output for the get_terms function
