### PR TITLE
Fix totals metrics to use segmented data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 Development
 -----------
 
-* Placeholder
+* Update hourly `totals_metrics` calculation to properly use only the segment of the model.
 
 2.8.2
 -----

--- a/eemeter/caltrack/hourly.py
+++ b/eemeter/caltrack/hourly.py
@@ -396,12 +396,12 @@ def fit_caltrack_hourly_model_segment(segment_name, segment_data):
         warnings=warnings,
     )
     if model:
+        this_segment_data = segment_data[segment_data.weight > 0]
         predicted_value = pd.Series(
-            model.fit().predict(),
-            index=segment_data[~pd.isnull(segment_data.weight)].index,
+            model.fit().predict(this_segment_data),
         )
         segment_model.totals_metrics = ModelMetrics(
-            segment_data.meter_value, predicted_value, len(model_params)
+            this_segment_data.meter_value, predicted_value, len(model_params)
         )
     else:
         segment_model.totals_metrics = None

--- a/eemeter/caltrack/hourly.py
+++ b/eemeter/caltrack/hourly.py
@@ -397,9 +397,7 @@ def fit_caltrack_hourly_model_segment(segment_name, segment_data):
     )
     if model:
         this_segment_data = segment_data[segment_data.weight > 0]
-        predicted_value = pd.Series(
-            model.fit().predict(this_segment_data),
-        )
+        predicted_value = pd.Series(model.fit().predict(this_segment_data))
         segment_model.totals_metrics = ModelMetrics(
             this_segment_data.meter_value, predicted_value, len(model_params)
         )


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure tests pass and coverage has not fallen `docker-compose run --rm test`.
- [x] Update the [CHANGELOG.md](../CHANGELOG.md) to describe your changes in a bulleted list under the "Development" section at the top of the changelog. If this section does not exist, create it.
- [x] Make sure code style follows PEP 008 using `docker-compose run --rm blacken`.
- [x] Make sure that new functions and classes have inline docstrings and are
  included in [docs/api.rst](../docs/api.rst) for the sphinx build. Please use [numpy-style docstrings](https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html#google-vs-numpy).
  Sphinx docs can be built with the following command: `docker-compose run --rm --entrypoint="make -C docs html" shell`. Please note and fix any warnings.
- [x] Make sure that all git commits are have the "Signed-off-by" message for
  the Developer Certificate of Origin. When you're making a commit, just add
  the `-s/--signoff` flag (e.g., `git commit -s`).

### Description

Update hourly totals_metrics so that it properly only calculates metrics on a segment of the data.