### PR TITLE
Add fromJson to be able to reload a CalTRACKUsagePerDayModelResults

### DIFF
--- a/eemeter/caltrack/hourly.py
+++ b/eemeter/caltrack/hourly.py
@@ -262,11 +262,13 @@ class CalTRACKHourlyModel(SegmentedModel):
             for s in data.get('segment_models')
         ]
 
-        c = cls(
-            segment_models,
-            pd.read_json(data.get('occupancy_lookup'), orient="split"),
-            pd.read_json(data.get('temperature_bins'), orient="split")
-            )
+        occupancy_lookup = pd.read_json(data.get('occupancy_lookup'), orient='split')
+        occupancy_lookup.index = occupancy_lookup.index.astype(pd.Categorical(range(0, 168)))
+
+        c = cls(segment_models,
+                occupancy_lookup,
+                pd.read_json(data.get('temperature_bins'), orient="split")
+                )
 
         return c
 

--- a/eemeter/caltrack/hourly.py
+++ b/eemeter/caltrack/hourly.py
@@ -263,7 +263,7 @@ class CalTRACKHourlyModel(SegmentedModel):
         ]
 
         occupancy_lookup = pd.read_json(data.get('occupancy_lookup'), orient='split')
-        occupancy_lookup.index = occupancy_lookup.index.astype(pd.Categorical(range(0, 168)))
+        occupancy_lookup.index = occupancy_lookup.index.astype('category')
 
         c = cls(segment_models,
                 occupancy_lookup,

--- a/eemeter/caltrack/hourly.py
+++ b/eemeter/caltrack/hourly.py
@@ -139,7 +139,7 @@ class CalTRACKHourlyModelResults(object):
         return data
 
     @classmethod
-    def fromJson(cls, data):
+    def from_json(cls, data):
         """ Loads a JSON-serializable representation into the model state.
 
         The input of this function is a dict which can be the result
@@ -150,7 +150,7 @@ class CalTRACKHourlyModelResults(object):
         model = None
         d = data.get('model')
         if d:
-            model = CalTRACKHourlyModel.fromJson(d)
+            model = CalTRACKHourlyModel.from_json(d)
 
         c = cls(
             data.get('status'),
@@ -164,10 +164,10 @@ class CalTRACKHourlyModelResults(object):
         # for reconstruction (like the input pandas) ...
         d = data.get('avgs_metrics')
         if d:
-            c.avgs_metrics = ModelMetrics.fromJson(d)
+            c.avgs_metrics = ModelMetrics.from_json(d)
         d = data.get('totals_metrics')
         if d:
-            c.totals_metrics = ModelMetrics.fromJson(d)
+            c.totals_metrics = ModelMetrics.from_json(d)
         return c
 
     def predict(self, prediction_index, temperature_data, **kwargs):
@@ -250,7 +250,7 @@ class CalTRACKHourlyModel(SegmentedModel):
         return data
 
     @classmethod
-    def fromJson(cls, data):
+    def from_json(cls, data):
         """ Loads a JSON-serializable representation into the model state.
 
         The input of this function is a dict which can be the result
@@ -258,7 +258,7 @@ class CalTRACKHourlyModel(SegmentedModel):
         """
 
         segment_models = [
-            CalTRACKSegmentModel.fromJson(s)
+            CalTRACKSegmentModel.from_json(s)
             for s in data.get('segment_models')
         ]
 

--- a/eemeter/caltrack/hourly.py
+++ b/eemeter/caltrack/hourly.py
@@ -138,6 +138,38 @@ class CalTRACKHourlyModelResults(object):
         }
         return data
 
+    @classmethod
+    def fromJson(cls, data):
+        """ Loads a JSON-serializable representation into the model state.
+
+        The input of this function is a dict which can be the result
+        of :any:`json.loads`.
+        """
+
+        # "model" is a CalTRACKHourlyModel that was serialized
+        model = None
+        d = data.get('model')
+        if d:
+            model = CalTRACKHourlyModel.fromJson(d)
+
+        c = cls(
+            data.get('status'),
+            data.get('method_name'),
+            model=model,
+            warnings=data.get('warnings'),
+            metadata=data.get('metadata'),
+            settings=data.get('settings'))
+
+        # Note the metrics do not contain all the data needed
+        # for reconstruction (like the input pandas) ...
+        d = data.get('avgs_metrics')
+        if d:
+            c.avgs_metrics = ModelMetrics.fromJson(d)
+        d = data.get('totals_metrics')
+        if d:
+            c.totals_metrics = ModelMetrics.fromJson(d)
+        return c
+
     def predict(self, prediction_index, temperature_data, **kwargs):
         """ Predict over a particular index using temperature data.
 
@@ -216,6 +248,27 @@ class CalTRACKHourlyModel(SegmentedModel):
             }
         )
         return data
+
+    @classmethod
+    def fromJson(cls, data):
+        """ Loads a JSON-serializable representation into the model state.
+
+        The input of this function is a dict which can be the result
+        of :any:`json.loads`.
+        """
+
+        segment_models = [
+            CalTRACKSegmentModel.fromJson(s)
+            for s in data.get('segment_models')
+        ]
+
+        c = cls(
+            segment_models,
+            pd.read_json(data.get('occupancy_lookup'), orient="split"),
+            pd.read_json(data.get('temperature_bins'), orient="split")
+            )
+
+        return c
 
 
 def caltrack_hourly_fit_feature_processor(

--- a/eemeter/caltrack/usage_per_day.py
+++ b/eemeter/caltrack/usage_per_day.py
@@ -185,6 +185,41 @@ class CalTRACKUsagePerDayModelResults(object):
             data["candidates"] = [candidate.json() for candidate in self.candidates]
         return data
 
+    @classmethod
+    def fromJson(cls, data):
+        """ Loads a JSON-serializable representation into the model state.
+
+        The input of this function is a dict which can be the result
+        of :any:`json.loads`.
+        """
+
+        # "model" is a CalTRACKUsagePerDayCandidateModel that was serialized
+        model = None
+        d = data.get('model')
+        if d:
+            model = CalTRACKUsagePerDayCandidateModel.fromJson(d)
+
+        c = cls(
+            data.get('status'),
+            data.get('method_name'),
+            interval=data.get('interval'),
+            model=model,
+            r_squared_adj=data.get('r_squared_adj'),
+            candidates=data.get('candidates'),
+            warnings=data.get('warnings'),
+            metadata=data.get('metadata'),
+            settings=data.get('settings'))
+
+        # Note the metrics do not contain all the data needed
+        # for reconstruction (like the input pandas) ...
+        d = data.get('avgs_metrics')
+        if d:
+            c.avgs_metrics = ModelMetrics.fromJson(d)
+        d = data.get('totals_metrics')
+        if d:
+            c.totals_metrics = ModelMetrics.fromJson(d)
+        return c
+
     def predict(
         self,
         prediction_index,
@@ -343,6 +378,24 @@ class CalTRACKUsagePerDayCandidateModel(object):
             "r_squared_adj": _noneify(self.r_squared_adj),
             "warnings": [w.json() for w in self.warnings],
         }
+
+    @classmethod
+    def fromJson(cls, data):
+        """ Loads a JSON-serializable representation into the model state.
+
+        The input of this function is a dict which can be the result
+        of :any:`json.loads`.
+        """
+
+        c = cls(
+            data.get('model_type'),
+            data.get('formula'),
+            data.get('status'),
+            model_params=data.get('model_params'),
+            r_squared_adj=data.get('r_squared_adj'),
+            warnings=data.get('warnings'))
+
+        return c
 
     def predict(
         self,

--- a/eemeter/caltrack/usage_per_day.py
+++ b/eemeter/caltrack/usage_per_day.py
@@ -186,7 +186,7 @@ class CalTRACKUsagePerDayModelResults(object):
         return data
 
     @classmethod
-    def fromJson(cls, data):
+    def from_json(cls, data):
         """ Loads a JSON-serializable representation into the model state.
 
         The input of this function is a dict which can be the result
@@ -197,7 +197,7 @@ class CalTRACKUsagePerDayModelResults(object):
         model = None
         d = data.get('model')
         if d:
-            model = CalTRACKUsagePerDayCandidateModel.fromJson(d)
+            model = CalTRACKUsagePerDayCandidateModel.from_json(d)
 
         c = cls(
             data.get('status'),
@@ -214,10 +214,10 @@ class CalTRACKUsagePerDayModelResults(object):
         # for reconstruction (like the input pandas) ...
         d = data.get('avgs_metrics')
         if d:
-            c.avgs_metrics = ModelMetrics.fromJson(d)
+            c.avgs_metrics = ModelMetrics.from_json(d)
         d = data.get('totals_metrics')
         if d:
-            c.totals_metrics = ModelMetrics.fromJson(d)
+            c.totals_metrics = ModelMetrics.from_json(d)
         return c
 
     def predict(
@@ -380,7 +380,7 @@ class CalTRACKUsagePerDayCandidateModel(object):
         }
 
     @classmethod
-    def fromJson(cls, data):
+    def from_json(cls, data):
         """ Loads a JSON-serializable representation into the model state.
 
         The input of this function is a dict which can be the result

--- a/eemeter/metrics.py
+++ b/eemeter/metrics.py
@@ -363,7 +363,7 @@ class ModelMetrics(object):
         }
 
     @classmethod
-    def fromJson(cls, data):
+    def from_json(cls, data):
         """ Loads a JSON-serializable representation into the model state.
 
         The input of this function is a dict which can be the result

--- a/eemeter/metrics.py
+++ b/eemeter/metrics.py
@@ -87,6 +87,65 @@ def _json_safe_float(number):
     return float(number)
 
 
+class ModelMetricsFromJson(object):
+
+    def __init__(
+        self,
+        observed_length,
+        predicted_length,
+        merged_length,
+        num_parameters,
+        observed_mean,
+        predicted_mean,
+        observed_variance,
+        predicted_variance,
+        observed_skew,
+        predicted_skew,
+        observed_kurtosis,
+        predicted_kurtosis,
+        observed_cvstd,
+        predicted_cvstd,
+        r_squared,
+        r_squared_adj,
+        rmse,
+        rmse_adj,
+        cvrmse,
+        cvrmse_adj,
+        mape,
+        mape_no_zeros,
+        num_meter_zeros,
+        nmae,
+        nmbe,
+        autocorr_resid
+    ):
+        self.observed_length = observed_length
+        self.predicted_length = predicted_length
+        self.merged_length = merged_length
+        self.num_parameters = num_parameters
+        self.observed_mean = observed_mean
+        self.predicted_mean = predicted_mean
+        self.observed_variance = observed_variance
+        self.predicted_variance = predicted_variance
+        self.observed_skew = observed_skew
+        self.predicted_skew = predicted_skew
+        self.observed_kurtosis = observed_kurtosis
+        self.predicted_kurtosis = predicted_kurtosis
+        self.observed_cvstd = observed_cvstd
+        self.predicted_cvstd = predicted_cvstd
+        self.r_squared = r_squared
+        self.r_squared_adj = r_squared_adj
+        self.rmse = rmse
+        self.rmse_adj = rmse_adj
+        self.cvrmse = cvrmse
+        self.cvrmse_adj = cvrmse_adj
+        self.mape = mape
+        self.mape_no_zeros = mape_no_zeros
+        self.num_meter_zeros = num_meter_zeros
+        self.nmae = nmae
+        self.nmbe = nmbe
+        self.autocorr_resid = autocorr_resid
+
+
 class ModelMetrics(object):
     """ Contains measures of model fit and summary statistics on the input series.
 
@@ -302,3 +361,41 @@ class ModelMetrics(object):
             "nmbe": _json_safe_float(self.nmbe),
             "autocorr_resid": _json_safe_float(self.autocorr_resid),
         }
+
+    @classmethod
+    def fromJson(cls, data):
+        """ Loads a JSON-serializable representation into the model state.
+
+        The input of this function is a dict which can be the result
+        of :any:`json.loads`.
+        """
+
+        c = ModelMetricsFromJson(
+            data.get("observed_length"),
+            data.get("predicted_length"),
+            data.get("merged_length"),
+            data.get("num_parameters"),
+            data.get("observed_mean"),
+            data.get("predicted_mean"),
+            data.get("observed_variance"),
+            data.get("predicted_variance"),
+            data.get("observed_skew"),
+            data.get("predicted_skew"),
+            data.get("observed_kurtosis"),
+            data.get("predicted_kurtosis"),
+            data.get("observed_cvstd"),
+            data.get("predicted_cvstd"),
+            data.get("r_squared"),
+            data.get("r_squared_adj"),
+            data.get("rmse"),
+            data.get("rmse_adj"),
+            data.get("cvrmse"),
+            data.get("cvrmse_adj"),
+            data.get("mape"),
+            data.get("mape_no_zeros"),
+            data.get("num_meter_zeros"),
+            data.get("nmae"),
+            data.get("nmbe"),
+            data.get("autocorr_resid"))
+
+        return c

--- a/eemeter/segmentation.py
+++ b/eemeter/segmentation.py
@@ -118,7 +118,7 @@ class CalTRACKSegmentModel(object):
         return data
 
     @classmethod
-    def fromJson(cls, data):
+    def from_json(cls, data):
         """ Loads a JSON-serializable representation into the model state.
 
         The input of this function is a dict which can be the result

--- a/eemeter/segmentation.py
+++ b/eemeter/segmentation.py
@@ -117,6 +117,24 @@ class CalTRACKSegmentModel(object):
         }
         return data
 
+    @classmethod
+    def fromJson(cls, data):
+        """ Loads a JSON-serializable representation into the model state.
+
+        The input of this function is a dict which can be the result
+        of :any:`json.loads`.
+        """
+
+        c = cls(
+            data.get('segment_name'),
+            None,
+            data.get('formula'),
+            data.get('model_params'),
+            warnings=data.get('warnings')
+            )
+
+        return c
+
 
 class SegmentedModel(object):
     """ Represent a model which has been broken into multiple model segments (for

--- a/tests/test_json_serialization.py
+++ b/tests/test_json_serialization.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+
+   Copyright 2014-2020 OpenEEmeter contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+"""
+import eemeter
+import json
+
+
+def test_json_daily():
+    meter_data, temperature_data, sample_metadata = (
+        eemeter.load_sample("il-electricity-cdd-hdd-daily")
+    )
+
+    blackout_start_date = sample_metadata["blackout_start_date"]
+    blackout_end_date = sample_metadata["blackout_end_date"]
+
+    # get meter data suitable for fitting a baseline model
+    baseline_meter_data, warnings = eemeter.get_baseline_data(
+        meter_data, end=blackout_start_date, max_days=365
+    )
+
+    # create a design matrix (the input to the model fitting step)
+    baseline_design_matrix = eemeter.create_caltrack_daily_design_matrix(
+        baseline_meter_data, temperature_data,
+    )
+
+    # build a CalTRACK model
+    baseline_model = eemeter.fit_caltrack_usage_per_day_model(
+        baseline_design_matrix,
+    )
+
+    # get a year of reporting period data
+    reporting_meter_data, warnings = eemeter.get_reporting_data(
+        meter_data, start=blackout_end_date, max_days=365
+    )
+
+    # compute metered savings
+    metered_savings_dataframe, error_bands = eemeter.metered_savings(
+        baseline_model, reporting_meter_data,
+        temperature_data, with_disaggregated=True
+    )
+
+    # total metered savings
+    total_metered_savings = metered_savings_dataframe.metered_savings.sum()
+
+    # test JSON
+    json_str = json.dumps(baseline_model.json())
+
+    m = eemeter.CalTRACKUsagePerDayModelResults.from_json(json.loads(json_str))
+
+    # compute metered savings from the loaded model
+    metered_savings_dataframe, error_bands = eemeter.metered_savings(
+        m, reporting_meter_data,
+        temperature_data, with_disaggregated=True
+    )
+
+    # total metered savings
+    total_metered_savings_2 = metered_savings_dataframe.metered_savings.sum()
+
+    assert total_metered_savings == total_metered_savings_2
+
+
+def test_json_hourly():
+    meter_data, temperature_data, sample_metadata = (
+        eemeter.load_sample("il-electricity-cdd-hdd-hourly")
+    )
+
+    blackout_start_date = sample_metadata["blackout_start_date"]
+    blackout_end_date = sample_metadata["blackout_end_date"]
+
+    # get meter data suitable for fitting a baseline model
+    baseline_meter_data, warnings = eemeter.get_baseline_data(
+        meter_data, end=blackout_start_date, max_days=365
+    )
+
+    # create a design matrix for occupancy and segmentation
+    preliminary_design_matrix = (
+        eemeter.create_caltrack_hourly_preliminary_design_matrix(
+            baseline_meter_data, temperature_data,
+        )
+    )
+
+    # build 12 monthly models - each step from now on operates on each segment
+    segmentation = eemeter.segment_time_series(
+        preliminary_design_matrix.index,
+        'three_month_weighted'
+    )
+
+    # assign an occupancy status to each hour of the week (0-167)
+    occupancy_lookup = eemeter.estimate_hour_of_week_occupancy(
+        preliminary_design_matrix,
+        segmentation=segmentation,
+    )
+
+    # assign temperatures to bins
+    temperature_bins = eemeter.fit_temperature_bins(
+        preliminary_design_matrix,
+        segmentation=segmentation,
+    )
+
+    # build a design matrix for each monthly segment
+    segmented_design_matrices = (
+        eemeter.create_caltrack_hourly_segmented_design_matrices(
+            preliminary_design_matrix,
+            segmentation,
+            occupancy_lookup,
+            temperature_bins,
+        )
+    )
+
+    # build a CalTRACK hourly model
+    baseline_model = eemeter.fit_caltrack_hourly_model(
+        segmented_design_matrices,
+        occupancy_lookup,
+        temperature_bins,
+    )
+
+    # get a year of reporting period data
+    reporting_meter_data, warnings = eemeter.get_reporting_data(
+        meter_data, start=blackout_end_date, max_days=365
+    )
+
+    # compute metered savings
+    metered_savings_dataframe, error_bands = eemeter.metered_savings(
+        baseline_model, reporting_meter_data,
+        temperature_data, with_disaggregated=True
+    )
+
+    # total metered savings
+    total_metered_savings = metered_savings_dataframe.metered_savings.sum()
+
+    # test JSON
+    json_str = json.dumps(baseline_model.json())
+
+    m = eemeter.CalTRACKHourlyModelResults.from_json(json.loads(json_str))
+
+    # compute metered savings from the loaded model
+    metered_savings_dataframe, error_bands = eemeter.metered_savings(
+        m, reporting_meter_data,
+        temperature_data, with_disaggregated=True
+    )
+
+    # total metered savings
+    total_metered_savings_2 = metered_savings_dataframe.metered_savings.sum()
+
+    assert total_metered_savings == total_metered_savings_2


### PR DESCRIPTION
Following up on https://lists.lfenergy.org/g/openeemeter/topic/how_to_persist_and/39896919

This works by loading the results of the mode json() output, following the tutorial this allows to use it to get to the same results:



```

meter_data, temperature_data, sample_metadata = (
    eemeter.load_sample("il-electricity-cdd-hdd-daily")
)

# the dates if an analysis "blackout" period during which a project was performed.
blackout_start_date = sample_metadata["blackout_start_date"]
blackout_end_date = sample_metadata["blackout_end_date"]

# get meter data suitable for fitting a baseline model
baseline_meter_data, warnings = eemeter.get_baseline_data(
    meter_data, end=blackout_start_date, max_days=365
)

# create a design matrix (the input to the model fitting step)
baseline_design_matrix = eemeter.create_caltrack_daily_design_matrix(
    baseline_meter_data, temperature_data,
)

# build a CalTRACK model
baseline_model = eemeter.fit_caltrack_usage_per_day_model(
    baseline_design_matrix,
)

# get a year of reporting period data
reporting_meter_data, warnings = eemeter.get_reporting_data(
    meter_data, start=blackout_end_date, max_days=365
)

# compute metered savings for the year of the reporting period we've selected
metered_savings_dataframe, error_bands = eemeter.metered_savings(
    baseline_model, reporting_meter_data,
    temperature_data, with_disaggregated=True
)

# total metered savings
total_metered_savings = metered_savings_dataframe.metered_savings.sum()




# test JSON

jsonStr = json.dumps(baseline_model.json())

# OR a static string from it:
jsonStr =  '{"status": "SUCCESS", "method_name": "caltrack_usage_per_day", "interval": "daily", "model": {"model_type": "cdd_hdd", "formula": "meter_value ~ cdd_68 + hdd_53", "status": "QUALIFIED", "model_params": {"intercept": 13.472385591795213, "beta_cdd": 2.516255026490126, "beta_hdd": 1.1122947857443488, "cooling_balance_point": 68, "heating_balance_point": 53}, "r_squared_adj": 0.7684732992831353, "warnings": []}, "r_squared_adj": 0.7684732992831353, "warnings": [], "metadata": {}, "settings": {"fit_cdd": true, "minimum_non_zero_cdd": 10, "minimum_non_zero_hdd": 10, "minimum_total_cdd": 20, "minimum_total_hdd": 20, "beta_cdd_maximum_p_value": 1, "beta_hdd_maximum_p_value": 1}, "totals_metrics": {"observed_length": 365.0, "predicted_length": 365.0, "merged_length": 365.0, "num_parameters": 2.0, "observed_mean": 28.515205479452053, "predicted_mean": 28.515205479452053, "observed_variance": 227.14091865640836, "predicted_variance": 174.8406827417312, "observed_skew": 0.8886811331096771, "predicted_skew": 0.5455712763914577, "observed_kurtosis": 0.8614282249213239, "predicted_kurtosis": -0.6097327958678194, "observed_cvstd": 0.5292573816587004, "predicted_cvstd": 0.4643446881483751, "r_squared": 0.7697454240123474, "r_squared_adj": 0.7684732992831338, "rmse": 7.2318902034445225, "rmse_adj": 7.25178539977947, "cvrmse": 0.2536152232413613, "cvrmse_adj": 0.25431292806236583, "mape": 0.24130173784949416, "mape_no_zeros": 0.24130173784949416, "num_meter_zeros": 0.0, "nmae": 0.19518739588748232, "nmbe": -1.2151806242792632e-16, "autocorr_resid": -0.014795668094989898}, "avgs_metrics": {"observed_length": 365.0, "predicted_length": 365.0, "merged_length": 365.0, "num_parameters": 2.0, "observed_mean": 28.515205479452053, "predicted_mean": 28.515205479452053, "observed_variance": 227.14091865640836, "predicted_variance": 174.8406827417312, "observed_skew": 0.8886811331096771, "predicted_skew": 0.5455712763914577, "observed_kurtosis": 0.8614282249213239, "predicted_kurtosis": -0.6097327958678194, "observed_cvstd": 0.5292573816587004, "predicted_cvstd": 0.4643446881483751, "r_squared": 0.7697454240123474, "r_squared_adj": 0.7684732992831338, "rmse": 7.2318902034445225, "rmse_adj": 7.25178539977947, "cvrmse": 0.2536152232413613, "cvrmse_adj": 0.25431292806236583, "mape": 0.24130173784949416, "mape_no_zeros": 0.24130173784949416, "num_meter_zeros": 0.0, "nmae": 0.19518739588748232, "nmbe": -1.2151806242792632e-16, "autocorr_resid": -0.014795668094989898}, "candidates": null}'

m = eemeter.CalTRACKUsagePerDayModelResults.fromJson(json.loads(jsonStr))

# those are still needed to get the total_metered_savings, reload them here

meter_data, temperature_data, sample_metadata = (
    eemeter.load_sample("il-electricity-cdd-hdd-daily")
)

# the dates if an analysis "blackout" period during which a project was performed.
blackout_start_date = sample_metadata["blackout_start_date"]
blackout_end_date = sample_metadata["blackout_end_date"]

# get a year of reporting period data
reporting_meter_data, warnings = eemeter.get_reporting_data(
    meter_data, start=blackout_end_date, max_days=365
)

# compute metered savings for the year of the reporting period we've selected
metered_savings_dataframe, error_bands = eemeter.metered_savings(
    m, reporting_meter_data,
    temperature_data, with_disaggregated=True
)

# total metered savings
total_metered_savings = metered_savings_dataframe.metered_savings.sum()

```