### PR TITLE
Fix issue regarding get_reporting_data when tz is non-UTC.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 Development
 -----------
 
-* Placeholder
+* Fix issue with `get_reporting_data` when passing data with non-UTC timezones.
 
 2.8.5
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 Development
 -----------
 
-* Fix issue with `get_reporting_data` when passing data with non-UTC timezones.
+* Fix issue with `get_reporting_data` and `get_baseline_data` when passing data with non-UTC timezones.
 
 2.8.5
 -----

--- a/eemeter/transform.py
+++ b/eemeter/transform.py
@@ -449,14 +449,14 @@ def get_reporting_data(
     start_inf = False
     if start is None:
         # py datetime min/max are out of range of pd.Timestamp min/max
-        start_limit = pytz.UTC.localize(pd.Timestamp.min)
+        start_limit = pytz.UTC.localize(pd.Timestamp.min) + timedelta(days=1)
         start_inf = True
     else:
         start_limit = start
 
     end_inf = False
     if end is None:
-        end_target = pytz.UTC.localize(pd.Timestamp.max)
+        end_target = pytz.UTC.localize(pd.Timestamp.max) - timedelta(days=1)
         end_inf = True
     else:
         end_target = end

--- a/eemeter/transform.py
+++ b/eemeter/transform.py
@@ -293,14 +293,14 @@ def get_baseline_data(
     start_inf = False
     if start is None:
         # py datetime min/max are out of range of pd.Timestamp min/max
-        start_target = pytz.UTC.localize(pd.Timestamp.min)
+        start_target = pytz.UTC.localize(pd.Timestamp.min) + timedelta(days=1)
         start_inf = True
     else:
         start_target = start
 
     end_inf = False
     if end is None:
-        end_limit = pytz.UTC.localize(pd.Timestamp.max)
+        end_limit = pytz.UTC.localize(pd.Timestamp.max) - timedelta(days=1)
         end_inf = True
     else:
         end_limit = end

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -168,6 +168,14 @@ def test_get_baseline_data(il_electricity_cdd_hdd_hourly):
     assert len(warnings) == 0
 
 
+def test_get_baseline_data_with_timezones(il_electricity_cdd_hdd_hourly):
+    meter_data = il_electricity_cdd_hdd_hourly["meter_data"]
+    baseline_data, warnings = get_baseline_data(meter_data.tz_convert('America/New_York'))
+    assert len(warnings) == 0
+    baseline_data, warnings = get_baseline_data(meter_data.tz_convert('Australia/Sydney'))
+    assert len(warnings) == 0
+
+
 def test_get_baseline_data_with_end(il_electricity_cdd_hdd_hourly):
     meter_data = il_electricity_cdd_hdd_hourly["meter_data"]
     blackout_start_date = il_electricity_cdd_hdd_hourly["blackout_start_date"]

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -394,6 +394,14 @@ def test_get_reporting_data(il_electricity_cdd_hdd_hourly):
     assert len(warnings) == 0
 
 
+def test_get_reporting_data_with_timezones(il_electricity_cdd_hdd_hourly):
+    meter_data = il_electricity_cdd_hdd_hourly["meter_data"]
+    reporting_data, warnings = get_reporting_data(meter_data.tz_convert('America/New_York'))
+    assert len(warnings) == 0
+    reporting_data, warnings = get_reporting_data(meter_data.tz_convert('Australia/Sydney'))
+    assert len(warnings) == 0
+
+
 def test_get_reporting_data_with_start(il_electricity_cdd_hdd_hourly):
     meter_data = il_electricity_cdd_hdd_hourly["meter_data"]
     blackout_end_date = il_electricity_cdd_hdd_hourly["blackout_end_date"]


### PR DESCRIPTION
Signed-off-by: Steve <steve@recurve.com>

### Your checklist for this pull request

Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure tests pass and coverage has not fallen `docker-compose run --rm test`.
- [x] Update the [CHANGELOG.md](../CHANGELOG.md) to describe your changes in a bulleted list under the "Development" section at the top of the changelog. If this section does not exist, create it.
- [x] Make sure code style follows PEP 008 using `docker-compose run --rm blacken`.
- [x] Make sure that new functions and classes have inline docstrings and are
  included in [docs/api.rst](../docs/api.rst) for the sphinx build. Please use [numpy-style docstrings](https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html#google-vs-numpy).
  Sphinx docs can be built with the following command: `docker-compose run --rm --entrypoint="make -C docs html" shell`. Please note and fix any warnings.
- [x] Make sure that all git commits are have the "Signed-off-by" message for
  the Developer Certificate of Origin. When you're making a commit, just add
  the `-s/--signoff` flag (e.g., `git commit -s`).

### Description

Please describe your pull request.
