### PR TITLE
Add a figure parameter to the visualization methods

### DIFF
--- a/eemeter/caltrack/usage_per_day.py
+++ b/eemeter/caltrack/usage_per_day.py
@@ -204,6 +204,7 @@ class CalTRACKUsagePerDayModelResults(object):
     def plot(
         self,
         ax=None,
+        figure=None,
         title=None,
         figsize=None,
         with_candidates=False,
@@ -216,6 +217,8 @@ class CalTRACKUsagePerDayModelResults(object):
         ----------
         ax : :any:`matplotlib.axes.Axes`, optional
             Existing axes to plot on.
+        figure : :any:`matplotlib.figure`, optional
+            Something that implements subplots, if left to None uses matplotlib.pyplot
         title : :any:`str`, optional
             Chart title.
         figsize : :any:`tuple`, optional
@@ -231,16 +234,23 @@ class CalTRACKUsagePerDayModelResults(object):
         ax : :any:`matplotlib.axes.Axes`
             Matplotlib axes.
         """
-        try:
-            import matplotlib.pyplot as plt
-        except ImportError:  # pragma: no cover
-            raise ImportError("matplotlib is required for plotting.")
 
-        if figsize is None:
-            figsize = (10, 4)
+        # note: to avoid memeory leaks some application might prefer using  matplotlib.figure
+        # instead of matplotlib.pyplot
+        if not figure:
+            try:
+                import matplotlib.pyplot as plt
+            except ImportError:  # pragma: no cover
+                raise ImportError("matplotlib is required for plotting.")
 
-        if ax is None:
-            fig, ax = plt.subplots(figsize=figsize)
+            if figsize is None:
+                figsize = (10, 4)
+
+            if ax is None:
+                fig, ax = plt.subplots(figsize=figsize)
+        else:
+            if ax is None:
+                ax = figure.subplots()
 
         if temp_range is None:
             temp_range = (20, 90)


### PR DESCRIPTION
One issue with the current usage of pyplot is with webservers, for example the current plot code crashes (not an exception just a good old process crash) my python instance running Django ...
One alternative that works for me and could be useful to others is to use matplotlib.figure instead of pyplot (as recommended here https://matplotlib.org/faq/howto_faq.html#howto-webapp ) so for example this code is equivalent to the tutorial visualization section and produces the same graph without crashing (later for example one can base64 encode the image and stream it to a client, or store in a DB or upload it directly) : 

        from matplotlib.figure import Figure
        from io import BytesIO

        fig = Figure(figsize=(10, 4))
        ax = eemeter.plot_energy_signature(data['meter_data'], data['temperature_data'], figure=fig)
        model.plot(
            ax=ax, figure=fig, candidate_alpha=0.02, with_candidates=True, temp_range=(-5, 88)
        )
        buf = BytesIO()
        fig.savefig(buf, format="png")
