### PR TITLE
Use post obs in fsu calc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 Development
 -----------
 
-* Placeholder
+* Bugfix for FSU post period.
 
 2.9.1
 -----

--- a/eemeter/derivatives.py
+++ b/eemeter/derivatives.py
@@ -21,7 +21,6 @@ from scipy.stats import t
 
 from .caltrack.usage_per_day import CalTRACKUsagePerDayModelResults
 
-
 __all__ = ("metered_savings", "modeled_savings")
 
 
@@ -56,7 +55,7 @@ def _compute_fsu_error(
     t_stat,
     interval,
     post_obs,
-    total_base_energy,
+    total_post_energy,
     rmse_base_residuals,
     base_avg,
     base_obs,
@@ -73,7 +72,7 @@ def _compute_fsu_error(
         c_coeff = 1.00286
         months_reporting = float(post_obs) / 30.0
 
-    fsu_error_band = total_base_energy * (
+    fsu_error_band = total_post_energy * (
         t_stat
         * (a_coeff * months_reporting ** 2.0 + b_coeff * months_reporting + c_coeff)
         * (rmse_base_residuals / base_avg)
@@ -121,7 +120,7 @@ def _compute_error_bands_metered_savings(
 
     nprime = float(base_obs * (1 - autocorr_resid) / (1 + autocorr_resid))
 
-    total_base_energy = float(base_avg * base_obs)
+    total_post_energy = float(post_avg * post_obs)
 
     ols_total_agg_error, ols_model_agg_error, ols_noise_agg_error = _compute_ols_error(
         t_stat,
@@ -138,7 +137,7 @@ def _compute_error_bands_metered_savings(
         t_stat,
         interval,
         post_obs,
-        total_base_energy,
+        total_post_energy,
         rmse_base_residuals,
         base_avg,
         base_obs,
@@ -313,6 +312,8 @@ def _compute_error_bands_modeled_savings(
 
     base_avg_baseline = float(totals_metrics_baseline.observed_mean)
     base_avg_reporting = float(totals_metrics_reporting.observed_mean)
+    post_avg_baseline = float(results["modeled_baseline_usage"].mean())
+    post_avg_reporting = float(results["modeled_reporting_usage"].mean())
 
     # these result in division by zero error for fsu_error_band
     if (
@@ -343,14 +344,14 @@ def _compute_error_bands_modeled_savings(
         / (1 + autocorr_resid_reporting)
     )
 
-    total_base_energy_baseline = float(base_avg_baseline * base_obs_baseline)
-    total_base_energy_reporting = float(base_avg_reporting * base_obs_reporting)
+    total_post_energy_baseline = float(post_avg_baseline * post_obs_baseline)
+    total_post_energy_reporting = float(post_avg_reporting * post_obs_reporting)
 
     fsu_error_band_baseline = _compute_fsu_error(
         t_stat_baseline,
         interval_baseline,
         post_obs_baseline,
-        total_base_energy_baseline,
+        total_post_energy_baseline,
         rmse_base_residuals_baseline,
         base_avg_baseline,
         base_obs_baseline,
@@ -361,7 +362,7 @@ def _compute_error_bands_modeled_savings(
         t_stat_reporting,
         interval_reporting,
         post_obs_reporting,
-        total_base_energy_reporting,
+        total_post_energy_reporting,
         rmse_base_residuals_reporting,
         base_avg_reporting,
         base_obs_reporting,

--- a/tests/test_derivatives.py
+++ b/tests/test_derivatives.py
@@ -293,7 +293,7 @@ def test_metered_savings_cdd_hdd_daily_hourly_degree_days(
         "metered_savings",
     ]
     assert round(results.metered_savings.sum(), 2) == 1571.28
-    assert round(error_bands["FSU Error Band"], 2) == 601.52
+    assert round(error_bands["FSU Error Band"], 2) == 3.41
 
 
 def test_metered_savings_cdd_hdd_no_params(
@@ -324,7 +324,7 @@ def test_metered_savings_cdd_hdd_daily_with_disaggregated(
         "metered_savings",
         "reporting_observed",
     ]
-    assert round(error_bands["FSU Error Band"], 2) == 601.52
+    assert round(error_bands["FSU Error Band"], 2) == 3.41
 
 
 def test_modeled_savings_cdd_hdd_daily(
@@ -346,9 +346,9 @@ def test_modeled_savings_cdd_hdd_daily(
         "modeled_savings",
     ]
     assert round(results.modeled_savings.sum(), 2) == 168.58
-    assert round(error_bands["FSU Error Band: Baseline"], 2) == 601.52
-    assert round(error_bands["FSU Error Band: Reporting"], 2) == 534.78
-    assert round(error_bands["FSU Error Band"], 2) == 804.87
+    assert round(error_bands["FSU Error Band: Baseline"], 2) == 94.22
+    assert round(error_bands["FSU Error Band: Reporting"], 2) == 86.07
+    assert round(error_bands["FSU Error Band"], 2) == 127.61
 
 
 def test_modeled_savings_cdd_hdd_daily_hourly_degree_days(
@@ -371,9 +371,9 @@ def test_modeled_savings_cdd_hdd_daily_hourly_degree_days(
         "modeled_savings",
     ]
     assert round(results.modeled_savings.sum(), 2) == 168.58
-    assert round(error_bands["FSU Error Band: Baseline"], 2) == 601.52
-    assert round(error_bands["FSU Error Band: Reporting"], 2) == 534.78
-    assert round(error_bands["FSU Error Band"], 2) == 804.87
+    assert round(error_bands["FSU Error Band: Baseline"], 2) == 94.22
+    assert round(error_bands["FSU Error Band: Reporting"], 2) == 86.07
+    assert round(error_bands["FSU Error Band"], 2) == 127.61
 
 
 def test_modeled_savings_cdd_hdd_daily_baseline_model_no_params(
@@ -436,9 +436,9 @@ def test_modeled_savings_cdd_hdd_daily_with_disaggregated(
         "modeled_reporting_usage",
         "modeled_savings",
     ]
-    assert round(error_bands["FSU Error Band: Baseline"], 2) == 601.52
-    assert round(error_bands["FSU Error Band: Reporting"], 2) == 534.78
-    assert round(error_bands["FSU Error Band"], 2) == 804.87
+    assert round(error_bands["FSU Error Band: Baseline"], 2) == 94.22
+    assert round(error_bands["FSU Error Band: Reporting"], 2) == 86.07
+    assert round(error_bands["FSU Error Band"], 2) == 127.61
 
 
 def test_modeled_savings_daily_empty_temperature_data(
@@ -598,7 +598,7 @@ def test_modeled_savings_cdd_hdd_billing(
         "FSU Error Band: Baseline",
         "FSU Error Band: Reporting",
     ]
-    assert round(error_bands["FSU Error Band"], 2) == 156.89
+    assert round(error_bands["FSU Error Band"], 2) == 3.49
 
 
 @pytest.fixture


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] Make sure you are requesting to **pull a feature/bugfix branch** (right side). Don't request your master!
- [ ] Make sure tests pass and coverage has not fallen `docker-compose run --rm test`.
- [ ] Update the [CHANGELOG.md](../CHANGELOG.md) to describe your changes in a bulleted list under the "Development" section at the top of the changelog. If this section does not exist, create it.
- [ ] Make sure code style follows PEP 008 using `docker-compose run --rm blacken`.
- [ ] Make sure that new functions and classes have inline docstrings and are
  included in [docs/api.rst](../docs/api.rst) for the sphinx build. Please use [numpy-style docstrings](https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html#google-vs-numpy).
  Sphinx docs can be built with the following command: `docker-compose run --rm --entrypoint="make -C docs html" shell`. Please note and fix any warnings.
- [ ] Make sure that all git commits are have the "Signed-off-by" message for
  the Developer Certificate of Origin. When you're making a commit, just add
  the `-s/--signoff` flag (e.g., `git commit -s`).

### Description

Bugfix for issue in FSU error band calculation where baseline observed values was used instead post (reporting) period observed values.
