### PR TITLE
Fix dataframe input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Development
 -----------
 
 * Correct dataframe input behavior and final row temperature aggregation
+* Remove unnecessary datetime normalization in order to respect hour of day
+* Convert timestamps in certain warnings to strings to allow serialization
+
 
 4.0.0
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 Development
 -----------
 
-* Placeholder
+* Correct dataframe input behavior and final row temperature aggregation
 
 4.0.0
 -----

--- a/eemeter/eemeter/common/data_processor_utilities.py
+++ b/eemeter/eemeter/common/data_processor_utilities.py
@@ -93,7 +93,10 @@ def clean_billing_data(data, source_interval, warnings):
                         description=(
                             "Off-cycle reads found in billing monthly data having a duration of less than 25 days"
                         ),
-                        data=(data[(filter_ > 35) | (filter_ < 25)].index.to_list()),
+                        data=[
+                            timestamp.isoformat()
+                            for timestamp in data[(filter_ > 35) | (filter_ < 25)].index
+                        ],
                     )
                 )
 
@@ -110,7 +113,10 @@ def clean_billing_data(data, source_interval, warnings):
                         description=(
                             "Off-cycle reads found in billing monthly data having a duration of less than 25 days"
                         ),
-                        data=(data[(filter_ > 70) | (filter_ < 25)].index.to_list()),
+                        data=[
+                            timestamp.isoformat()
+                            for timestamp in data[(filter_ > 70) | (filter_ < 25)].index
+                        ],
                     )
                 )
 
@@ -299,7 +305,10 @@ def downsample_and_clean_daily_data(dataset, warnings):
                 description=(
                     "More than 50% of the high frequency Meter data is missing."
                 ),
-                data=(dataset[dataset.coverage <= 0.5].index.to_list()),
+                data=[
+                    timestamp.isoformat()
+                    for timestamp in dataset[dataset.coverage <= 0.5].index
+                ],
             )
         )
 

--- a/eemeter/eemeter/models/billing/data.py
+++ b/eemeter/eemeter/models/billing/data.py
@@ -259,7 +259,10 @@ class _BillingData(_DailyData):
                             description=(
                                 "More than 50% of the high frequency temperature data is missing."
                             ),
-                            data=(invalid_temperature_rows.index.to_list()),
+                            data=[
+                                timestamp.isoformat()
+                                for timestamp in invalid_temperature_rows.index
+                            ],
                         )
                     )
                     temperature_features.loc[

--- a/eemeter/eemeter/models/billing/data.py
+++ b/eemeter/eemeter/models/billing/data.py
@@ -235,12 +235,12 @@ class _BillingData(_DailyData):
             temperature_features["n_days_kept"] = 0  # unused
             temperature_features["n_days_dropped"] = 0  # unused
         else:
-            buffer_idx = pd.to_datetime("2090-01-01 00:00:00+00:00").tz_convert(
-                meter_index.tz
-            )
+            if not meter_index.empty:
+                buffer_idx = meter_index.max() + pd.Timedelta(days=1)
+                meter_index = meter_index.union([buffer_idx])
 
             temperature_features = compute_temperature_features(
-                meter_index.union([buffer_idx]),
+                meter_index,
                 temp_series,
                 data_quality=True,
             )

--- a/eemeter/eemeter/models/daily/data.py
+++ b/eemeter/eemeter/models/daily/data.py
@@ -107,25 +107,52 @@ class _DailyData:
         temperature_data.index = temperature_data.index.tz_convert(
             meter_data.index.tzinfo
         )
+
+        if temperature_data.empty:
+            raise ValueError("Temperature data cannot be empty.")
+        if meter_data.empty:
+            # reporting from_series always passes a full index of nan
+            raise ValueError("Meter data cannot by empty.")
+
         # TODO revisit the following index modifications; there may be a few unintuitive outcomes with offset data
-        # constrain temperature index to meter index
-        if not meter_data.empty:
-            meter_index_min = meter_data.index.min().normalize()
-            meter_index_max = meter_data.index.max().normalize() + pd.Timedelta(days=1)
-            temperature_data = temperature_data[
-                (temperature_data.index >= meter_index_min)
-                & (temperature_data.index < meter_index_max)
-            ]
         # constrain meter index to temperature index
-        if not temperature_data.empty:
-            temp_index_min = temperature_data.index.min().normalize()
-            temp_index_max = temperature_data.index.max().normalize() + pd.Timedelta(
-                days=1
+        temp_index_min = temperature_data.index.min().normalize()
+        temp_index_max = temperature_data.index.max().normalize() + pd.Timedelta(days=1)
+        # discards first period of meter data if temperature data starts mid-month
+        meter_data = meter_data[
+            (meter_data.index >= temp_index_min) & (meter_data.index < temp_index_max)
+        ]
+        if meter_data.empty:
+            raise ValueError("Meter and temperature data are fully misaligned.")
+
+        is_billing_data = False
+        if not meter_data.empty:
+            is_billing_data = compute_minimum_granularity(
+                meter_data.index, "billing"
+            ).startswith("billing")
+
+        # if billing detected, subtract one day from final index since dataframe input assumes final row is part of period
+        if is_billing_data:
+            new_index = meter_data.index[:-1].union(
+                [(meter_data.index[-1] - pd.Timedelta(days=1))]
             )
-            meter_data = meter_data[
-                (meter_data.index >= temp_index_min)
-                & (meter_data.index < temp_index_max)
-            ]
+            if len(new_index) == len(meter_data.index):
+                meter_data.index = new_index
+            else:
+                # handles the case of a 1 day off-cycle read at end of series
+                meter_data = meter_data[:-1]
+
+        # constrain temperature index to meter index
+        meter_index_min = meter_data.index.min().normalize()
+        meter_index_max = meter_data.index.max().normalize() + pd.Timedelta(days=1)
+        temperature_data = temperature_data[
+            (temperature_data.index >= meter_index_min)
+            & (temperature_data.index < meter_index_max)
+        ]
+        if is_billing_data:
+            # TODO consider adding warnings here about misaligned data and/or a final period that is not nan
+            meter_data.iloc[-1] = np.nan
+
         df = pd.concat([meter_data, temperature_data], axis=1)
         return cls(df, is_electricity_data)
 
@@ -153,12 +180,15 @@ class _DailyData:
         -------
             pd.DataFrame: The cleaned and processed meter value DataFrame.
         """
-        # Dropping the NaNs is beneficial when the meter data is spread over hourly temperature data, causing lots of NaNs
-        # But causes problems in detection of frequency when there are genuine missing values. The missing days are accounted for in the sufficiency_criteria_baseline method
-        # whereas they should actually be kept.
         meter_series = df["observed"].dropna()
         if meter_series.empty:
             return df["observed"].resample("D").first().to_frame()
+
+        # Dropping the NaNs is beneficial when the meter data is spread over hourly temperature data, causing lots of NaNs
+        # But causes problems in detection of frequency when there are genuine missing values. The missing days are accounted for in the sufficiency_criteria_baseline method
+        # whereas they should actually be kept.
+        start_date = df.index.min().normalize()
+        end_date = df.index.max().normalize()
         min_granularity = compute_minimum_granularity(meter_series.index, "daily")
         if min_granularity.startswith("billing"):
             # TODO : make this a warning instead of an exception
@@ -166,22 +196,16 @@ class _DailyData:
         meter_value_df = clean_billing_daily_data(
             meter_series, min_granularity, self.warnings
         )
-        # if np.isnan(meter_value_df.iloc[-1]['value']):
-        #     #TODO test behavior here. we might be able to get away with a dropna() if we alter the n_days check, but this is less aggressive
-        #     #TODO need to refactor the clean caltrack data method and remove the nan logic, this breaks when original df has nan in last row
-        #     meter_value_df = meter_value_df[:-1]
 
         meter_value_df = meter_value_df.rename(columns={"value": "observed"})
-        meter_value_df.index = (
-            meter_value_df.index.normalize()
-        )  # in case of daily data where hour is not midnight
+        meter_value_df.index = meter_value_df.index.normalize()
 
         # To account for the above issue, we create an index with all the days and then merge the meter_value_df with it
         # This will ensure that the missing days are kept in the dataframe
         # Create an index with all the days from the start and end date of 'meter_value_df'
         all_days_index = pd.date_range(
-            start=meter_value_df.index.min(),
-            end=meter_value_df.index.max(),
+            start=start_date,
+            end=end_date,
             freq="D",
             tz=df.index.tz,
         )
@@ -385,7 +409,7 @@ class _DailyData:
         expected_columns = [
             "observed",
             "temperature",
-        ]  # TODO will change when extending to report
+        ]
         # TODO maybe check datatypes
         if not set(expected_columns).issubset(set(df.columns)):
             # show the columns that are missing
@@ -584,6 +608,10 @@ class DailyReportingData(_DailyData):
             )
             if tzinfo:
                 meter_data = meter_data.tz_convert(tzinfo)
+        if meter_data.empty:
+            raise ValueError(
+                "Pass meter_data=None rather than an empty series in order to explicitly create a temperature-only reporting data instance."
+            )
         return super().from_series(meter_data, temperature_data, is_electricity_data)
 
     def _check_data_sufficiency(self, sufficiency_df):

--- a/eemeter/eemeter/models/daily/data.py
+++ b/eemeter/eemeter/models/daily/data.py
@@ -280,12 +280,11 @@ class _DailyData:
             temperature_features["n_days_dropped"] = 0  # unused
         else:
             # TODO hacky method of avoiding the last index nan convention
-            buffer_idx = pd.to_datetime("2090-01-01 00:00:00+00:00").tz_convert(
-                meter_index.tz
-            )
-
+            if not meter_index.empty:
+                buffer_idx = meter_index.max() + pd.Timedelta(days=1)
+                meter_index = meter_index.union([buffer_idx])
             temperature_features = compute_temperature_features(
-                meter_index.union([buffer_idx]),
+                meter_index,
                 temp_series,
                 data_quality=True,
             )

--- a/eemeter/eemeter/models/daily/data.py
+++ b/eemeter/eemeter/models/daily/data.py
@@ -395,7 +395,10 @@ class _DailyData:
                             description=(
                                 "More than 50% of the high frequency temperature data is missing."
                             ),
-                            data=(invalid_temperature_rows.index.to_list()),
+                            data=[
+                                timestamp.isoformat()
+                                for timestamp in invalid_temperature_rows.index
+                            ],
                         )
                     )
                     temperature_features.loc[

--- a/tests/test_derivatives.py
+++ b/tests/test_derivatives.py
@@ -154,7 +154,7 @@ def test_metered_savings_cdd_hdd_billing(
     )
     results = baseline_model_billing.predict(reporting_data)
     metered_savings = results["predicted"] - results["observed"]
-    assert round(metered_savings.sum(), 2) == 1597.99
+    assert round(metered_savings.sum(), 2) == 1604.94
 
 
 def test_metered_savings_cdd_hdd_billing_no_reporting_data(
@@ -178,7 +178,7 @@ def test_metered_savings_cdd_hdd_billing_no_reporting_data(
         "model_split",
         "model_type",
     ]
-    assert round(results.predicted.sum(), 2) == 1642.6
+    assert round(results.predicted.sum(), 2) == 1649.77
 
 
 def test_metered_savings_cdd_hdd_billing_single_record_reporting_data(
@@ -275,38 +275,15 @@ def reporting_meter_data_billing_wrong_timestamp():
 
 
 def test_metered_savings_cdd_hdd_billing_reporting_data_wrong_timestamp(
-    baseline_model_billing,
     reporting_meter_data_billing_wrong_timestamp,
     reporting_temperature_data,
 ):
-    # results, error_bands = metered_savings(
-    #     baseline_model_billing,
-    #     reporting_meter_data_billing_wrong_timestamp,
-    #     reporting_temperature_data,
-    #     billing_data=True,
-    # )
-    results = baseline_model_billing.predict(
+    with pytest.raises(ValueError):
         BillingReportingData.from_series(
             reporting_meter_data_billing_wrong_timestamp,
             reporting_temperature_data,
             is_electricity_data=True,
         )
-    )
-
-    assert list(results.columns) == [
-        "season",
-        "day_of_week",
-        "weekday_weekend",
-        "temperature",
-        "observed",
-        "predicted",
-        "predicted_unc",
-        "heating_load",
-        "cooling_load",
-        "model_split",
-        "model_type",
-    ]
-    assert round(results.predicted.sum(), 2) == 0.0
 
 
 def test_modeled_savings_cdd_hdd_daily(
@@ -495,7 +472,7 @@ def test_modeled_savings_cdd_hdd_billing(
         "model_split",
         "model_type",
     ]
-    assert round(results.predicted.sum(), 2) == 8268.3
+    assert round(results.predicted.sum(), 2) == 8243.0
 
 
 @pytest.fixture
@@ -505,36 +482,15 @@ def reporting_meter_data_billing_not_aligned():
 
 
 def test_metered_savings_not_aligned_reporting_data(
-    baseline_model_billing,
     reporting_meter_data_billing_not_aligned,
     reporting_temperature_data,
 ):
-    # results, error_bands = metered_savings(
-    #     baseline_model_billing,
-    #     reporting_meter_data_billing_not_aligned,
-    #     reporting_temperature_data,
-    #     billing_data=True,
-    # )
-    results = baseline_model_billing.predict(
+    with pytest.raises(ValueError):
         BillingReportingData.from_series(
             reporting_meter_data_billing_not_aligned,
             reporting_temperature_data,
             is_electricity_data=True,
         )
-    )
-    assert list(results.columns) == [
-        "season",
-        "day_of_week",
-        "weekday_weekend",
-        "temperature",
-        "predicted",
-        "predicted_unc",
-        "heating_load",
-        "cooling_load",
-        "model_split",
-        "model_type",
-    ]
-    assert round(results.predicted.sum(), 2) == 0
 
 
 @pytest.fixture

--- a/tests/test_derivatives.py
+++ b/tests/test_derivatives.py
@@ -51,15 +51,11 @@ def baseline_data_daily(il_electricity_cdd_hdd_daily):
     baseline_meter_data, warnings = get_baseline_data(
         meter_data, end=blackout_start_date
     )
-    # TODO create a few tests with non-midnight datetimes
-    # baseline_meter_data.index = map(lambda x: x.replace(hour=6), baseline_meter_data.index)
     baseline_data = DailyBaselineData.from_series(
         baseline_meter_data, temperature_data, is_electricity_data=True
     )
 
     return baseline_data
-
-
 @pytest.fixture
 def baseline_model_daily(baseline_data_daily):
     model_results = DailyModel().fit(baseline_data_daily, ignore_disqualification=True)
@@ -106,7 +102,7 @@ def test_metered_savings_cdd_hdd_daily(
     )
     results = baseline_model_daily.predict(reporting_data)
     metered_savings = results["predicted"] - results["observed"]
-    assert round(metered_savings.sum(), 2) == 1642.34
+    assert round(metered_savings.sum(), 2) == 1643.61
 
 
 @pytest.fixture
@@ -156,7 +152,7 @@ def test_metered_savings_cdd_hdd_billing(
     )
     results = baseline_model_billing.predict(reporting_data)
     metered_savings = results["predicted"] - results["observed"]
-    assert round(metered_savings.sum(), 2) == 1607.53
+    assert round(metered_savings.sum(), 2) == 1605.14
 
 
 def test_metered_savings_cdd_hdd_billing_no_reporting_data(
@@ -180,7 +176,7 @@ def test_metered_savings_cdd_hdd_billing_no_reporting_data(
         "model_split",
         "model_type",
     ]
-    assert round(results.predicted.sum(), 2) == 1652.31
+    assert round(results.predicted.sum(), 2) == 1607.1
 
 
 def test_metered_savings_cdd_hdd_billing_single_record_reporting_data(
@@ -267,7 +263,7 @@ def test_metered_savings_cdd_hdd_billing_single_record_baseline_data(
         "model_split",
         "model_type",
     ]
-    assert round(results.predicted.sum() - results.observed.sum(), 2) == 1785.8
+    assert round(results.predicted.sum() - results.observed.sum(), 2) == 1785.84
 
 
 @pytest.fixture
@@ -302,7 +298,7 @@ def test_modeled_savings_cdd_hdd_daily(
     modeled_savings = (
         baseline_model_result["predicted"] - reporting_model_result["predicted"]
     )
-    assert round(modeled_savings.sum(), 2) == 183.03
+    assert round(modeled_savings.sum(), 2) == 177.02
 
 
 # TODO move to dataclass testing
@@ -474,7 +470,7 @@ def test_modeled_savings_cdd_hdd_billing(
         "model_split",
         "model_type",
     ]
-    assert round(results.predicted.sum(), 2) == 8261.98
+    assert round(results.predicted.sum(), 2) == 8245.37
 
 
 @pytest.fixture
@@ -543,7 +539,7 @@ def test_metered_savings_model_single_record(
         "model_split",
         "model_type",
     ]
-    assert round(results.predicted.sum() - results.observed.sum(), 2) == 1447.89
+    assert round(results.predicted.sum() - results.observed.sum(), 2) == 1447.93
 
 
 @pytest.fixture

--- a/tests/test_derivatives.py
+++ b/tests/test_derivatives.py
@@ -51,6 +51,8 @@ def baseline_data_daily(il_electricity_cdd_hdd_daily):
     baseline_meter_data, warnings = get_baseline_data(
         meter_data, end=blackout_start_date
     )
+    # TODO create a few tests with non-midnight datetimes
+    # baseline_meter_data.index = map(lambda x: x.replace(hour=6), baseline_meter_data.index)
     baseline_data = DailyBaselineData.from_series(
         baseline_meter_data, temperature_data, is_electricity_data=True
     )
@@ -104,7 +106,7 @@ def test_metered_savings_cdd_hdd_daily(
     )
     results = baseline_model_daily.predict(reporting_data)
     metered_savings = results["predicted"] - results["observed"]
-    assert round(metered_savings.sum(), 2) == 1643.61
+    assert round(metered_savings.sum(), 2) == 1642.34
 
 
 @pytest.fixture
@@ -154,7 +156,7 @@ def test_metered_savings_cdd_hdd_billing(
     )
     results = baseline_model_billing.predict(reporting_data)
     metered_savings = results["predicted"] - results["observed"]
-    assert round(metered_savings.sum(), 2) == 1604.94
+    assert round(metered_savings.sum(), 2) == 1607.53
 
 
 def test_metered_savings_cdd_hdd_billing_no_reporting_data(
@@ -178,7 +180,7 @@ def test_metered_savings_cdd_hdd_billing_no_reporting_data(
         "model_split",
         "model_type",
     ]
-    assert round(results.predicted.sum(), 2) == 1649.77
+    assert round(results.predicted.sum(), 2) == 1652.31
 
 
 def test_metered_savings_cdd_hdd_billing_single_record_reporting_data(
@@ -300,7 +302,7 @@ def test_modeled_savings_cdd_hdd_daily(
     modeled_savings = (
         baseline_model_result["predicted"] - reporting_model_result["predicted"]
     )
-    assert round(modeled_savings.sum(), 2) == 177.02
+    assert round(modeled_savings.sum(), 2) == 183.03
 
 
 # TODO move to dataclass testing
@@ -472,7 +474,7 @@ def test_modeled_savings_cdd_hdd_billing(
         "model_split",
         "model_type",
     ]
-    assert round(results.predicted.sum(), 2) == 8243.0
+    assert round(results.predicted.sum(), 2) == 8261.98
 
 
 @pytest.fixture

--- a/tests/test_derivatives.py
+++ b/tests/test_derivatives.py
@@ -104,7 +104,7 @@ def test_metered_savings_cdd_hdd_daily(
     )
     results = baseline_model_daily.predict(reporting_data)
     metered_savings = results["predicted"] - results["observed"]
-    assert round(metered_savings.sum(), 2) == 1642.34
+    assert round(metered_savings.sum(), 2) == 1643.61
 
 
 @pytest.fixture
@@ -154,7 +154,7 @@ def test_metered_savings_cdd_hdd_billing(
     )
     results = baseline_model_billing.predict(reporting_data)
     metered_savings = results["predicted"] - results["observed"]
-    assert round(metered_savings.sum(), 2) == 1598.03
+    assert round(metered_savings.sum(), 2) == 1597.99
 
 
 def test_metered_savings_cdd_hdd_billing_no_reporting_data(
@@ -265,7 +265,7 @@ def test_metered_savings_cdd_hdd_billing_single_record_baseline_data(
         "model_split",
         "model_type",
     ]
-    assert round(results.predicted.sum() - results.observed.sum(), 2) == 1785.81
+    assert round(results.predicted.sum() - results.observed.sum(), 2) == 1785.8
 
 
 @pytest.fixture
@@ -323,7 +323,7 @@ def test_modeled_savings_cdd_hdd_daily(
     modeled_savings = (
         baseline_model_result["predicted"] - reporting_model_result["predicted"]
     )
-    assert round(modeled_savings.sum(), 2) == 182.42
+    assert round(modeled_savings.sum(), 2) == 177.02
 
 
 # TODO move to dataclass testing
@@ -585,7 +585,7 @@ def test_metered_savings_model_single_record(
         "model_split",
         "model_type",
     ]
-    assert round(results.predicted.sum() - results.observed.sum(), 2) == 1447.88
+    assert round(results.predicted.sum() - results.observed.sum(), 2) == 1447.89
 
 
 @pytest.fixture


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure tests pass and coverage has not fallen `docker-compose run --rm test`.
- [x] Update the [CHANGELOG.md](../CHANGELOG.md) to describe your changes in a bulleted list under the "Development" section at the top of the changelog. If this section does not exist, create it.
- [x] Make sure code style follows PEP 008 using `docker-compose run --rm blacken`.
- [x] Make sure that new functions and classes have inline docstrings and are
  included in [docs/api.rst](../docs/api.rst) for the sphinx build. Please use [numpy-style docstrings](https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html#google-vs-numpy).
  Sphinx docs can be built with the following command: `docker-compose run --rm --entrypoint="make -C docs html" shell`. Please note and fix any warnings.
- [x] Make sure that all git commits are have the "Signed-off-by" message for
  the Developer Certificate of Origin. When you're making a commit, just add
  the `-s/--signoff` flag (e.g., `git commit -s`).

### Description

Baseline and reporting dataclasses currently trim NaN rows from their resulting dataframe--this fix preserves the initial structure of the data. Additionally, the final row of temperature is now calculated correctly.