### PR TITLE
Handle ambiguous and nonexistent local times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 Development
 -----------
 
-* Placeholder
+* Handle ambiguous and nonexistent local times when creating daily dataclass
 
 4.0.6
 -----

--- a/eemeter/eemeter/models/daily/data.py
+++ b/eemeter/eemeter/models/daily/data.py
@@ -259,6 +259,8 @@ class _DailyData:
             end=end_date,
             freq="D",
             tz=df.index.tz,
+            ambiguous=True,
+            nonexistent="shift_forward",
         )
         all_days_df = pd.DataFrame(index=all_days_index)
         # the following drops common days to handle DST issues with pytz.


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure tests pass and coverage has not fallen `docker-compose run --rm test`.
- [x] Update the [CHANGELOG.md](../CHANGELOG.md) to describe your changes in a bulleted list under the "Development" section at the top of the changelog. If this section does not exist, create it.
- [x] Make sure code style follows PEP 008 using `docker-compose run --rm blacken`.
- [x] Make sure that new functions and classes have inline docstrings valid docstrings and any public classes and methods are included members in the docs/reference files. Please use [google-style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
  Sphinx docs can be built with the following command: `docker-compose run --rm --entrypoint="make -C docs html" shell`. Please note and fix any warnings.
- [x] Make sure that all git commits are have the "Signed-off-by" message for
  the Developer Certificate of Origin. When you're making a commit, just add
  the `-s/--signoff` flag (e.g., `git commit -s`).

### Description

Fixes daily dataclass behavior when local times that coincide with DST shifts are used
