### PR TITLE
Add platform to docker-compose for nlopt wheel

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3'
 services:
   shell:
     build: .
+    platform: linux/amd64
     image: eemeter_shell
     stdin_open: true
     tty: true


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure tests pass and coverage has not fallen `docker-compose run --rm test`.
- [x] Update the [CHANGELOG.md](../CHANGELOG.md) to describe your changes in a bulleted list under the "Development" section at the top of the changelog. If this section does not exist, create it.
- [x] Make sure code style follows PEP 008 using `docker-compose run --rm blacken`.
- [x] Make sure that new functions and classes have inline docstrings valid docstrings and any public classes and methods are included members in the docs/reference files. Please use [google-style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
  Sphinx docs can be built with the following command: `docker-compose run --rm --entrypoint="make -C docs html" shell`. Please note and fix any warnings.
- [x] Make sure that all git commits are have the "Signed-off-by" message for
  the Developer Certificate of Origin. When you're making a commit, just add
  the `-s/--signoff` flag (e.g., `git commit -s`).

### Description

nlopt doesn't have a wheel for docker inside of Mac M1/M2, but by specifying the platform in docker to linux it is able to pull down the correct wheel.

This isn't written in a changelog since its not related to the actual package itself.
