### PR TITLE
Constrain balance point on T_min_seg and T_max_seg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 Development
 -----------
 
-* Placeholder
+* Constrain eemeter daily model balance points to T_min_seg and T_max_seg rather than T_min and T_max.
 
 4.0.7
 -----

--- a/eemeter/eemeter/models/daily/base_models/full_model.py
+++ b/eemeter/eemeter/models/daily/base_models/full_model.py
@@ -143,9 +143,9 @@ def get_full_model_x(model_key, x, T_min, T_max, T_min_seg, T_max_seg):
         [c_hdd_bp, c_hdd_beta, intercept] = x
 
         if c_hdd_bp < T_min_seg:
-            cdd_bp = hdd_bp = T_min
+            cdd_bp = hdd_bp = T_min_seg
         elif c_hdd_bp > T_max_seg:
-            cdd_bp = hdd_bp = T_max
+            cdd_bp = hdd_bp = T_max_seg
         else:
             hdd_bp = cdd_bp = c_hdd_bp
 

--- a/eemeter/eemeter/models/daily/optimize_results.py
+++ b/eemeter/eemeter/models/daily/optimize_results.py
@@ -170,7 +170,7 @@ def reduce_model(
     elif (hdd_beta != 0) and (cdd_beta == 0) and (pct_hdd_k == 0):
         coef_id = ["c_hdd_bp", "c_hdd_beta", "intercept"]
         if hdd_bp >= T_max_seg:
-            hdd_bp = T_max
+            hdd_bp = T_max_seg
 
         hdd_beta = -hdd_beta
         x = [hdd_bp, hdd_beta, intercept]
@@ -178,7 +178,7 @@ def reduce_model(
     elif (hdd_beta == 0) and (cdd_beta != 0) and (pct_cdd_k == 0):
         coef_id = ["c_hdd_bp", "c_hdd_beta", "intercept"]
         if cdd_bp <= T_min_seg:
-            cdd_bp = T_min
+            cdd_bp = T_min_seg
 
         x = [cdd_bp, cdd_beta, intercept]
 

--- a/eemeter/eemeter/models/hourly/derivatives.py
+++ b/eemeter/eemeter/models/hourly/derivatives.py
@@ -44,9 +44,7 @@ def _compute_ols_error(
         t_stat * rmse_base_residuals * (post_obs * base_obs / nprime) ** 0.5
     )
 
-    ols_total_agg_error = (
-        ols_model_agg_error**2.0 + ols_noise_agg_error**2.0
-    ) ** 0.5
+    ols_total_agg_error = (ols_model_agg_error**2.0 + ols_noise_agg_error**2.0) ** 0.5
 
     return ols_total_agg_error, ols_model_agg_error, ols_noise_agg_error
 
@@ -357,9 +355,7 @@ def _compute_error_bands_modeled_savings(
     return {
         "FSU Error Band: Baseline": fsu_error_band_baseline,
         "FSU Error Band: Reporting": fsu_error_band_reporting,
-        "FSU Error Band": (
-            fsu_error_band_baseline**2.0 + fsu_error_band_reporting**2.0
-        )
+        "FSU Error Band": (fsu_error_band_baseline**2.0 + fsu_error_band_reporting**2.0)
         ** 0.5,
     }
 

--- a/tests/daily_model/test_daily_data.py
+++ b/tests/daily_model/test_daily_data.py
@@ -837,8 +837,10 @@ def test_offset_aggregations_hourly(il_electricity_cdd_hdd_hourly):
 def test_dst_handling():
     # 2020-03-08 02:00 is nonexistent, should push to 03:00
     tz = "America/New_York"
-    idx = DatetimeIndex([Timestamp("2020-03-07 02", tz=tz), Timestamp("2021-03-06 02", tz=tz)])
-    df = DataFrame({"observed": [1]*2, "temperature": [50]*2}, index=idx)
+    idx = DatetimeIndex(
+        [Timestamp("2020-03-07 02", tz=tz), Timestamp("2021-03-06 02", tz=tz)]
+    )
+    df = DataFrame({"observed": [1] * 2, "temperature": [50] * 2}, index=idx)
     baseline = DailyBaselineData(df, is_electricity_data=True)
     assert len(baseline.df) == 365
     hours, counts = np.unique(baseline.df.index.hour, return_counts=True)
@@ -847,8 +849,10 @@ def test_dst_handling():
 
     # 2020-11-01 01:00 is ambiguous, single index should be chosen
     tz = "America/New_York"
-    idx = DatetimeIndex([Timestamp("2020-03-07 01", tz=tz), Timestamp("2021-03-06 01", tz=tz)])
-    df = DataFrame({"observed": [1]*2, "temperature": [50]*2}, index=idx)
+    idx = DatetimeIndex(
+        [Timestamp("2020-03-07 01", tz=tz), Timestamp("2021-03-06 01", tz=tz)]
+    )
+    df = DataFrame({"observed": [1] * 2, "temperature": [50] * 2}, index=idx)
     baseline = DailyBaselineData(df, is_electricity_data=True)
     assert len(baseline.df) == 365
     assert (baseline.df.index.hour == 1).all()

--- a/tests/daily_model/test_optimize_results.py
+++ b/tests/daily_model/test_optimize_results.py
@@ -216,8 +216,8 @@ class TestOptimizeResult:
             "intercept",
         ]
         loss_alpha = 2.0
-        C = np.array([1, 2, 3, 4, 5, 6, 7]*2)
-        T = np.array([1, 2, 3, 4, 5, 6, 7]*2)
+        C = np.array([1, 2, 3, 4, 5, 6, 7] * 2)
+        T = np.array([1, 2, 3, 4, 5, 6, 7] * 2)
         model = np.array([1, 2, 3, 4, 5, 6, 7])
         resid = np.array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7])
         weight = np.array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7])

--- a/tests/daily_model/test_optimize_results.py
+++ b/tests/daily_model/test_optimize_results.py
@@ -216,8 +216,8 @@ class TestOptimizeResult:
             "intercept",
         ]
         loss_alpha = 2.0
-        C = np.array([1, 2, 3, 4, 5, 6, 7])
-        T = np.array([1, 2, 3, 4, 5, 6, 7])
+        C = np.array([1, 2, 3, 4, 5, 6, 7]*2)
+        T = np.array([1, 2, 3, 4, 5, 6, 7]*2)
         model = np.array([1, 2, 3, 4, 5, 6, 7])
         resid = np.array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7])
         weight = np.array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7])
@@ -268,15 +268,15 @@ class TestOptimizeResult:
         # test that _refine_model sets coef_id and x correctly
         optimize_result._refine_model()
         assert optimize_result.coef_id == ["c_hdd_bp", "c_hdd_beta", "intercept"]
-        assert optimize_result.x == pytest.approx(np.array([1, 5, 7]))
+        assert optimize_result.x == pytest.approx(np.array([4, 5, 7]))
 
     def test_eval(self, optimize_result):
         # test that eval returns the correct values
         T = np.array([1, 2, 3, 4, 5])
         model, f_unc, hdd_load, cdd_load = optimize_result.eval(T)
-        assert model == pytest.approx(np.array([7, 12, 17, 22, 27]))
+        assert model == pytest.approx(np.array([7, 7, 7, 7, 12]))
         assert f_unc == pytest.approx(
             np.array([2.15564961, 2.15564961, 2.15564961, 2.15564961, 2.15564961])
         )
         assert hdd_load == pytest.approx(np.array([0, 0, 0, 0, 0]))
-        assert cdd_load == pytest.approx(np.array([0, 5, 10, 15, 20]))
+        assert cdd_load == pytest.approx(np.array([0, 0, 0, 0, 5]))

--- a/tests/test_derivatives.py
+++ b/tests/test_derivatives.py
@@ -543,7 +543,7 @@ def test_metered_savings_model_single_record(
         "model_split",
         "model_type",
     ]
-    assert round(results.predicted.sum() - results.observed.sum(), 2) == 1447.89
+    assert round(results.predicted.sum() - results.observed.sum(), 2) == 1458.91
 
 
 @pytest.fixture


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure tests pass and coverage has not fallen `docker-compose run --rm test`.
- [x] Update the [CHANGELOG.md](../CHANGELOG.md) to describe your changes in a bulleted list under the "Development" section at the top of the changelog. If this section does not exist, create it.
- [x] Make sure code style follows PEP 008 using `docker-compose run --rm blacken`.
- [x] Make sure that new functions and classes have inline docstrings valid docstrings and any public classes and methods are included members in the docs/reference files. Please use [google-style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
  Sphinx docs can be built with the following command: `docker-compose run --rm --entrypoint="make -C docs html" shell`. Please note and fix any warnings.
- [x] Make sure that all git commits are have the "Signed-off-by" message for
  the Developer Certificate of Origin. When you're making a commit, just add
  the `-s/--signoff` flag (e.g., `git commit -s`).

### Description

I noticed this when testing with a resstock building, and finding that one of the models (weekend summer-shoulder) looked like this:

![image](https://github.com/user-attachments/assets/a6f36fbb-0618-436e-a0f8-2bfa64a3c5a8)

After deep diving, I noticed that even though the optimized result included a balance point of ~57, since it was slightly lower than `T_min_seg` (which was about 57.1), it overrode the balance point to `T_min=51`, which shifted the line to the left farther away from the temperature values.

After the above fix, it shifted the balance point to ~57.1, which seems much more reasonable.

<img width="876" alt="image" src="https://github.com/user-attachments/assets/76a915e9-8593-46de-8e9a-bd852decb6c1">


