### PR TITLE
Fixed issue with docs build by pinning old version of griffe

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,3 +5,4 @@ mkdocs-material==9.5.29
 mkdocs-material-extensions==1.3.1
 mkdocstrings==0.25.1
 mkdocstrings-python==1.10.5
+griffe==0.47.0


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] Make sure you are requesting to **pull a feature/bugfix branch** (right side). Don't request your master!
- [ ] Make sure tests pass and coverage has not fallen `docker-compose run --rm test`.
- [ ] Update the [CHANGELOG.md](../CHANGELOG.md) to describe your changes in a bulleted list under the "Development" section at the top of the changelog. If this section does not exist, create it.
- [ ] Make sure code style follows PEP 008 using `docker-compose run --rm blacken`.
- [ ] Make sure that new functions and classes have inline docstrings valid docstrings and any public classes and methods are included members in the docs/reference files. Please use [google-style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
  Sphinx docs can be built with the following command: `docker-compose run --rm --entrypoint="make -C docs html" shell`. Please note and fix any warnings.
- [x] Make sure that all git commits are have the "Signed-off-by" message for
  the Developer Certificate of Origin. When you're making a commit, just add
  the `-s/--signoff` flag (e.g., `git commit -s`).

### Description

Another build realted one. This should fix the issue with the docs not building on PR merges.
