### PR TITLE
Ensures the model.warnings/model.disqualification fields exist across both models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Changelog
 Development
 -----------
 
-* Placeholder
+* Rename HourlyBaselineData.sufficiency_warnings -> HourlyBaselineData.warnings
+* Add disqualification field to HourlyBaselineData and HourlyReportingData
 
 4.0.7
 -----

--- a/eemeter/eemeter/models/hourly/data.py
+++ b/eemeter/eemeter/models/hourly/data.py
@@ -38,6 +38,8 @@ class HourlyReportingData:
         df = self._correct_frequency(df)
 
         self.df = df
+        self.warnings = []
+        self.disqualification = []
 
     def _correct_frequency(self, df: pd.DataFrame):
         meter = df["observed"]
@@ -90,7 +92,8 @@ class HourlyBaselineData(HourlyReportingData):
         df = self._correct_frequency(df)
 
         self.df = df
-        self.sufficiency_warnings = self._check_data_sufficiency()
+        self.warnings = self._check_data_sufficiency()
+        self.disqualification = []
 
     def _check_data_sufficiency(self):
         meter = self.df["observed"].rename("meter_value")


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure tests pass and coverage has not fallen `docker-compose run --rm test`.
- [x] Update the [CHANGELOG.md](../CHANGELOG.md) to describe your changes in a bulleted list under the "Development" section at the top of the changelog. If this section does not exist, create it.
- [x] Make sure code style follows PEP 008 using `docker-compose run --rm blacken`.
- [x] Make sure that new functions and classes have inline docstrings valid docstrings and any public classes and methods are included members in the docs/reference files. Please use [google-style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
  Sphinx docs can be built with the following command: `docker-compose run --rm --entrypoint="make -C docs html" shell`. Please note and fix any warnings.
- [x] Make sure that all git commits are have the "Signed-off-by" message for
  the Developer Certificate of Origin. When you're making a commit, just add
  the `-s/--signoff` flag (e.g., `git commit -s`).

### Description

This normalizes the naming convention for warnings and disqualifications across the hourly and daily models.
