### PR TITLE
Fix hourly metrics deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 Development
 -----------
 
-* Placeholder
+* Fix serialization and deserialization of metrics.
 
 4.0.7
 -----

--- a/eemeter/eemeter/models/hourly/model.py
+++ b/eemeter/eemeter/models/hourly/model.py
@@ -168,9 +168,17 @@ class CalTRACKHourlyModelResults(object):
         d = data.get("avgs_metrics")
         if d:
             c.avgs_metrics = ModelMetrics.from_json(d)  # pragma: no cover
+            c.avgs_metrics = {
+                segment_name: ModelMetrics.from_json(seg_d)
+                for segment_name, seg_d in d.items()
+            }
         d = data.get("totals_metrics")
         if d:
-            c.totals_metrics = ModelMetrics.from_json(d)
+            c.totals_metrics = ModelMetrics.from_json(d)  # pragma: no cover
+            c.totals_metrics = {
+                segment_name: ModelMetrics.from_json(seg_d)
+                for segment_name, seg_d in d.items()
+            }
         return c
 
     def predict(self, prediction_index, temperature_data, **kwargs):

--- a/tests/test_json_serialization.py
+++ b/tests/test_json_serialization.py
@@ -157,6 +157,12 @@ def test_json_hourly():
 
     assert result1["predicted"].sum() == result2["predicted"].sum()
 
+    # Check that model metrics are properly serialized/serialized
+    assert (
+        baseline_model.model.totals_metrics["dec-jan-feb-weighted"].observed_length
+        == m.model.totals_metrics["dec-jan-feb-weighted"].observed_length
+    )
+
 
 def test_legacy_deserialization_daily():
     legacy_model_dict = {


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure tests pass and coverage has not fallen `docker-compose run --rm test`.
- [x] Update the [CHANGELOG.md](../CHANGELOG.md) to describe your changes in a bulleted list under the "Development" section at the top of the changelog. If this section does not exist, create it.
- [x] Make sure code style follows PEP 008 using `docker-compose run --rm blacken`.
- [x] Make sure that new functions and classes have inline docstrings valid docstrings and any public classes and methods are included members in the docs/reference files. Please use [google-style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
  Sphinx docs can be built with the following command: `docker-compose run --rm --entrypoint="make -C docs html" shell`. Please note and fix any warnings.
- [x] Make sure that all git commits are have the "Signed-off-by" message for
  the Developer Certificate of Origin. When you're making a commit, just add
  the `-s/--signoff` flag (e.g., `git commit -s`).

### Description

The hourly metrics when deserialized were not taking into account that `model.totals_metrics` and `model.avgs_metrics` are dictionaries of the type `{segment_name: ModelMetrics}` rather than just a single instance of `ModelMetrics`, leading to all null metrics in the reserialized model.

This fixes that issue by loading it based on its dictionary format during deserialization.
