### PR TITLE
fix linear fit bug

### DIFF
--- a/eemeter/eemeter/models/daily/base_models/c_hdd_tidd.py
+++ b/eemeter/eemeter/models/daily/base_models/c_hdd_tidd.py
@@ -277,11 +277,11 @@ def _c_hdd_tidd_x0(T, obs, alpha, settings, smooth):
     idx_hdd = np.argwhere(T <= c_hdd_bp).flatten()
     idx_cdd = np.argwhere(T >= c_hdd_bp).flatten()
 
-    hdd_beta, _ = linear_fit(obs[idx_hdd], T[idx_hdd], alpha)
+    hdd_beta, _ = linear_fit(T[idx_hdd], obs[idx_hdd], alpha)
     if hdd_beta > 0:
         hdd_beta = 0
 
-    cdd_beta, _ = linear_fit(obs[idx_cdd], T[idx_cdd], alpha)
+    cdd_beta, _ = linear_fit(T[idx_cdd], obs[idx_cdd], alpha)
     if cdd_beta < 0:
         cdd_beta = 0
 
@@ -347,11 +347,11 @@ def _c_hdd_tidd_bp0(T, obs, alpha, settings, min_weight=0.0):
             idx_hdd = np.argwhere(T <= c_hdd_bp).flatten()
             idx_cdd = np.argwhere(T >= c_hdd_bp).flatten()
 
-            hdd_beta, _ = linear_fit(obs[idx_hdd], T[idx_hdd], alpha)
+            hdd_beta, _ = linear_fit(T[idx_hdd], obs[idx_hdd], alpha)
             if hdd_beta > 0:
                 hdd_beta = 0
 
-            cdd_beta, _ = linear_fit(obs[idx_cdd], T[idx_cdd], alpha)
+            cdd_beta, _ = linear_fit(T[idx_cdd], obs[idx_cdd], alpha)
             if cdd_beta < 0:
                 cdd_beta = 0
 

--- a/eemeter/eemeter/models/daily/utilities/base_model.py
+++ b/eemeter/eemeter/models/daily/utilities/base_model.py
@@ -85,7 +85,7 @@ def linear_fit(x, y, alpha):
         slope = res.slope
         intercept = res.intercept
     else:
-        slope, intercept, _, _ = theilslopes(x, y, alpha=0.95)
+        slope, intercept, _, _ = theilslopes(y, x, alpha=0.95)
 
     return slope, intercept
 

--- a/tests/daily_model/test_fit_model.py
+++ b/tests/daily_model/test_fit_model.py
@@ -28,7 +28,7 @@ class TestFitModel:
     @classmethod
     def setup_class(cls):
         # Create a sample meter data DataFrame from the test data
-        df = pd.read_csv("tests/daily_model/test_data.csv")
+        df = pd.read_csv("eemeter/tests/daily_model/test_data.csv")
         df.index = pd.to_datetime(df["datetime"])
         df = df[["temperature", "observed"]]
         cls.meter_data = DailyBaselineData(df, is_electricity_data=True)

--- a/tests/daily_model/test_fit_model.py
+++ b/tests/daily_model/test_fit_model.py
@@ -28,7 +28,7 @@ class TestFitModel:
     @classmethod
     def setup_class(cls):
         # Create a sample meter data DataFrame from the test data
-        df = pd.read_csv("eemeter/tests/daily_model/test_data.csv")
+        df = pd.read_csv("tests/daily_model/test_data.csv")
         df.index = pd.to_datetime(df["datetime"])
         df = df[["temperature", "observed"]]
         cls.meter_data = DailyBaselineData(df, is_electricity_data=True)

--- a/tests/daily_model/utilities/test_base_model.py
+++ b/tests/daily_model/utilities/test_base_model.py
@@ -125,7 +125,7 @@ def test_linear_fit():
     y = np.array([2, 4, 6, 8, 10])
     alpha = 0.95
     slope, intercept = linear_fit(x, y, alpha)
-    res = theilslopes(x, y, alpha=0.95)
+    res = theilslopes(y, x, alpha=0.95)
     assert slope == res[0]
     assert intercept == res[1]
 
@@ -137,7 +137,7 @@ def test_linear_fit():
     with pytest.raises(ValueError):
         res = linregress(x, y)
     assert slope == 0
-    assert intercept == 10
+    assert intercept == x[0]
 
 
 def test_get_smooth_coeffs():


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] Make sure you are requesting to **pull a feature/bugfix branch** (right side). Don't request your master!
- [ ] Make sure tests pass and coverage has not fallen `docker-compose run --rm test`.
- [ ] Update the [CHANGELOG.md](../CHANGELOG.md) to describe your changes in a bulleted list under the "Development" section at the top of the changelog. If this section does not exist, create it.
- [ ] Make sure code style follows PEP 008 using `docker-compose run --rm blacken`.
- [ ] Make sure that new functions and classes have inline docstrings valid docstrings and any public classes and methods are included members in the docs/reference files. Please use [google-style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
  Sphinx docs can be built with the following command: `docker-compose run --rm --entrypoint="make -C docs html" shell`. Please note and fix any warnings.
- [ ] Make sure that all git commits are have the "Signed-off-by" message for
  the Developer Certificate of Origin. When you're making a commit, just add
  the `-s/--signoff` flag (e.g., `git commit -s`).

### Description

Fixing linear_fit bug as scipy's theilslopes is (y, x) and linregress is (x, y).