### PR TITLE
Add NOTES.md: clustering improvements scratchpad

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,0 +1,44 @@
+# Clustering improvements — planned work
+
+This branch is the staging area for clustering algorithm improvements that
+go beyond the extraction work in PRs against the local opendsm-integration
+plan. Land items here as they're designed and implemented, then open
+upstream PRs once each piece is independently shippable.
+
+## spectral_divisive stabilization
+
+Two related cross-platform issues surfaced during the clustering reorg
+(#586) CI. Both were worked around in #586 rather than fixed:
+
+### 1. Degenerate eigenspace on pathologically separated data
+
+With `sep/std > 50`, inter-cluster affinity underflows to 0 in float32,
+the top-k Laplacian eigenvalues collapse within ULP, and different BLAS
+implementations pick different orthonormal bases. The score function
+then reads them as different *confident* winners (k=2/3/4 across
+Windows/Linux/macOS for the same input).
+
+Workaround in #586: changed the test fixture to a non-degenerate regime
+(`sep/std ≈ 5`, `n_per_cluster ≥ 50`). The original pathological
+fixtures (`sep/std=67`, `n=80, center_box=(-8, 8)`) couldn't be
+restored as test inputs without algorithmic stabilization.
+
+Proposed fix: detect degenerate eigenspace via eigenvalue spacing and
+bypass score-based selection in favour of eigengap when the top
+eigenvalues are within tolerance of each other.
+
+### 2. `_power_iteration_fiedler` non-convergence on macOS py3.11
+
+Returns `lambda2 = 0.0` on macOS py3.11 for a connected graph where
+`scipy.sparse.linalg.eigsh` correctly returns `~0.19`. Indicates the
+power iteration fails to converge or fails to deflate the trivial
+eigenvector on Apple Accelerate.
+
+Proposed fix: add convergence guards and better initialization to
+`_power_iteration_fiedler`.
+
+### Done when
+
+Both pathological fixtures (`sep/std=67`, `n=80, center_box=(-8, 8)`)
+can be restored as test inputs and the score-based k-selection
+produces the same winner across Linux/macOS/Windows runners.


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side). — `feature/distribution-transform-refactor` against `master`
- [ ] Make sure tests pass and coverage has not fallen `docker-compose run --rm test`. — verified locally: 179/179 new distribution_transform tests, 4/4 daily+billing regression tests, 57/57 clustering+adaptive_loss tests; cross-platform validation left to CI
- [x] Update the [CHANGELOG.md](../CHANGELOG.md) to describe your changes in a bulleted list under the "Development" section at the top of the changelog.
- [ ] Make sure code style follows PEP 008 using `docker-compose run --rm blacken`. — not run locally; happy to address any blacken diff in review
- [x] Make sure that new functions and classes have inline docstrings valid docstrings and any public classes and methods are included members in the docs/reference files.
- [x] Make sure that all git commits are have the "Signed-off-by" message for the Developer Certificate of Origin.

### Description

Class-based API for all distribution transforms. Each transform is now a class with `fit` / `transform` / `inverse_transform` / `to_dict` / `from_dict`, supporting per-dimension fitting, graceful skip on degenerate dimensions, and full serialization.

**New classes** (in `opendsm/common/stats/distribution_transform/`):
- `Standardize` — robust standardization via `mu_sigma`
- `Bisymlog` — bisymmetric log
- `YeoJohnson(robust=True | False)` — robust variant implements Raymaekers & Rousseeuw 2021; non-robust wraps `scipy.stats.yeojohnson`
- `BoxCox(robust=True | False)` — new transform, both variants

**Shared infrastructure:**
- `_base.py` — `TransformBase` + `PowerTransformMixin` (per-dim fit loop, skip rules, dict/JSON serialization)
- `_bc_yj_shared.py` — Box-Cox and Yeo-Johnson share Huber/Tukey weighting kernels and the `_fit_lambda` Brent optimization

**Removed:**
- `scipy_yeo_johnson.py` — replaced by `YeoJohnson(robust=False)`
- `raymaekers_robust_yeo_johnson.py` — replaced by `YeoJohnson(robust=True)`

**Updated:**
- `outliers_transformed.remove_outliers` — dispatches through a `_TRANSFORMS` dict keyed on the new transform names
- `OoM` in `opendsm/common/utils.py` — wraps input with `np.atleast_1d` so scalar inputs work with the new bisymlog code path

**Breaking change** (`comparison_groups/savings/settings.py:TransformChoice` enum):
- `SCIPY_YJ` / `ROBUST_SCIPY_YJ` / `ROBUST_YJ` removed
- New values: `YEO_JOHNSON`, `ROBUST_YEO_JOHNSON`, `BOX_COX`, `ROBUST_BOX_COX`
- `OutlierRejectionSettings.transform` default is `None`, so users who haven't opted into outlier rejection are unaffected. Users with serialized configs that set `transform` to one of the old YJ values will need to update.

**Tests added** (`tests/common/`): `test_standardize.py`, `test_bisymlog.py`, `test_yeo_johnson.py`, `test_box_cox.py` — 179 cases covering fit/transform invariance, roundtrips through `to_dict` / `from_dict`, per-dim skip behavior, NaN passthrough, and known-value regression checks against scipy.