### PR TITLE
Harden clustering against degenerate data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Changelog
 Development
 -----------
 
+* Bug fix (`clustering`): degenerate-data handling across the selection and algorithm layers.
+  - `ClusteringResult`: `.k` / `.metrics` / `.labels` raised `IndexError` when every candidate labeling was rejected by `prepare_labels` (empty `_labels_store`, e.g. all collapsed below `n_cluster_lower`). They now raise a clear `ValueError` naming `n_cluster_lower` when `k=1` is disallowed, and return the single cluster when it is allowed.
+  - `ClusteringResult`: when valid candidates exist but the council produces no scored winner, the fallback returns the labeling with the fewest clusters (`>= n_cluster_lower`) instead of the insertion-order-first one, and never a count below the lower bound.
+  - `ClusteringResult`: a single specified k (one distinct `k`) bypasses the gap gate and cross-k council entirely, returning the within-k best with full confidence.
+  - `SingleKMetrics`: add `unique_valid_labels` / `valid_label_count` (outlier label `-1` excluded); `ClusteringResult.k` uses the valid count.
+  - `bisect_k_medians`: bound the per-node split retries so unsplittable data (e.g. identical points) no longer loops forever — after the retry budget the node is accepted as a terminal cluster.
+  - `spectral`: the sparse self-tuning path falls back to a dense `eigh` of the smallest eigenpairs when ARPACK fails to converge (previously re-raised).
 * `comparison_groups` test suite: coverage across the package — `Data` ingestion (time-series and features-only), the `Comparison_Group_Algorithm` base, the public `CG_Clustering` / `Individual_Meter_Matching` / `Stratified_Sampling` / `random_sampling` flows, cluster bounds, `savings` correction-cap and settings validators and diagnostics, and equivalence / bin-count edge cases. Per-subpackage test directories made packages to avoid duplicate-basename collisions.
 * `comparison_groups/stratified_sampling`: modernized to match the rest of the package — single linear settings-driven `get_comparison_group` orchestration; standardize on the shared `id` column (was `meter_id`); fold the module-level constants into settings; expose diagnostics as methods on `Stratified_Sampling`; render diagnostic plots with matplotlib instead of plotnine; delete the dead `param_selection` / `const` modules and modernize class declarations. Output is pinned identical by new snapshot regression tests over the sampled comparison group.
 * `clustering`: use skfda `FourierBasis` (was the deprecated `Fourier`); suppress the invalid-log warning in the cluster-bound fallback.

--- a/opendsm/common/clustering/algorithms/bisect_k_medians.py
+++ b/opendsm/common/clustering/algorithms/bisect_k_medians.py
@@ -35,6 +35,9 @@ from opendsm.common.clustering.algorithms.k_medians import (
 from opendsm.common.clustering.metrics.labels import ClusteringResult
 
 
+_MAX_SPLIT_ATTEMPTS = 5  # reseed budget before a node is accepted as unsplittable
+
+
 def _cluster_inertia(data: np.ndarray, indices: np.ndarray) -> float:
     """Sum of squared L2 distances to the median centroid."""
     sub = data[indices]
@@ -88,7 +91,7 @@ def _bisect_k_medians_single(data, settings, seed):
     init_priority = (
         -_cluster_inertia(data, all_indices) if use_inertia else -float(n)
     )
-    heapq.heappush(heap, (init_priority, tiebreak, all_indices))
+    heapq.heappush(heap, (init_priority, tiebreak, all_indices, 0))
     tiebreak += 1
 
     current_k = 1
@@ -99,7 +102,7 @@ def _bisect_k_medians_single(data, settings, seed):
         if not heap:
             break
 
-        _, _, indices = heapq.heappop(heap)
+        _, _, indices, attempts = heapq.heappop(heap)
 
         if len(indices) < 2 * min_cs:
             continue
@@ -116,8 +119,12 @@ def _bisect_k_medians_single(data, settings, seed):
         n_left = int(left_mask.sum())
         n_right = int(right_mask.sum())
         if n_left < min_cs or n_right < min_cs:
-            heapq.heappush(heap, (0.0, tiebreak, indices))
-            tiebreak += 1
+            # Reseed and retry; after the budget is spent, leave the node
+            # unsplit (a terminal cluster) so the loop always terminates.
+            if attempts + 1 < _MAX_SPLIT_ATTEMPTS:
+                heapq.heappush(heap, (0.0, tiebreak, indices, attempts + 1))
+                tiebreak += 1
+
             continue
 
         left_idx = indices[left_mask]
@@ -133,7 +140,7 @@ def _bisect_k_medians_single(data, settings, seed):
                     -_cluster_inertia(data, child_idx) if use_inertia
                     else -float(len(child_idx))
                 )
-                heapq.heappush(heap, (priority, tiebreak, child_idx))
+                heapq.heappush(heap, (priority, tiebreak, child_idx, 0))
                 tiebreak += 1
 
         if current_k >= n_lower:

--- a/opendsm/common/clustering/algorithms/spectral/spectral.py
+++ b/opendsm/common/clustering/algorithms/spectral/spectral.py
@@ -154,7 +154,12 @@ def _single_spectral_clustering(data, settings, seed):
             eigenvalues = eigenvalues[idx]
             eigenvectors = eigenvectors[:, idx]
         except Exception:
-            raise
+            # ARPACK can fail to converge on large or ill-conditioned
+            # Laplacians; fall back to a dense solve of the smallest eigenpairs.
+            L_dense = L_sparse.toarray()
+            eigenvalues, eigenvectors = _scipy_eigh(
+                L_dense, subset_by_index=[0, n_eigvecs - 1]
+            )
         del L_sparse
 
         embedding = eigenvectors[:, :n_eigvecs]

--- a/opendsm/common/clustering/metrics/labels.py
+++ b/opendsm/common/clustering/metrics/labels.py
@@ -81,9 +81,6 @@ class LabelStore(ArbitraryPydanticModel):
     )
     _eigengap_scores: dict[int, float] | None = pydantic.PrivateAttr(default=None)
     _eigengap_weight: float = pydantic.PrivateAttr(default=0.0)
-    _unscored_merged: dict[int, list[np.ndarray]] = pydantic.PrivateAttr(
-        default_factory=dict,
-    )
     _insertion_order: list[SingleKMetrics | None] = pydantic.PrivateAttr(
         default_factory=list,
     )
@@ -152,7 +149,6 @@ class LabelStore(ArbitraryPydanticModel):
         )
 
         if data_clean is None:
-            self._unscored_merged.setdefault(k, []).append(full_merged)
             self._insertion_order.append(None)
             return None
 
@@ -271,7 +267,7 @@ class ClusteringResult(LabelStore):
     @property
     def k(self) -> int:
         """Number of non-outlier clusters in the best labeling."""
-        return len(np.unique(self._labels_best.labels))
+        return self._labels_best.valid_label_count
 
     @property
     def metrics(self) -> SingleKMetrics:
@@ -370,9 +366,30 @@ class ClusteringResult(LabelStore):
                 candidates.extend(self._labels_store[k])
 
         all_valid = [c for c in candidates if c is not None]
+        if not all_valid:
+            if not candidates:
+                raise ValueError("No labels have been added")
+
+            lower = self.n_cluster_lower
+            raise ValueError(
+                f"No clustering met the cluster-count constraints "
+                f"(n_cluster_lower={lower}): every candidate labeling was "
+                f"rejected — each collapsed below the lower bound or exceeded "
+                f"the maximum cluster count. The data may be degenerate."
+            )
+
         if len(all_valid) == 1:
             self.__dict__["_cache_selection_confidence"] = 1.0
+
             return all_valid[0]
+
+        # A single specified k needs no cross-k selection — return the
+        # within-k best directly and skip the gate and council.
+        if len(self.k_values) == 1:
+            only_k = self.k_values[0]
+            self.__dict__["_cache_selection_confidence"] = 1.0
+
+            return self._labels_k_best[only_k]
 
         # Gap statistic gate: check if any k>1 has genuine cluster
         # structure exceeding a uniform null.  If not, return k=1
@@ -432,11 +449,14 @@ class ClusteringResult(LabelStore):
         winner = council_candidates[winner_idx]
         if winner is not None:
             return winner
-        # Fallback: return the first valid k >= 2 candidate
-        for c in candidates:
-            if c is not None and lm_to_k.get(id(c), 0) >= 2:
-                return c
-        return all_valid[0]
+
+        # Council could not score the candidates; fall back to the labeling
+        # with the fewest clusters.  Every valid candidate cleared
+        # prepare_labels, so its cluster count is >= n_cluster_lower — the
+        # fallback can never drop below the user's lower bound.
+        smallest_k_winner = min(all_valid, key=lambda c: c.valid_label_count)
+
+        return smallest_k_winner
 
     def _build_cross_k_extra_scores(
         self,
@@ -481,14 +501,7 @@ class ClusteringResult(LabelStore):
         if cached is not None:
             return cached
 
-        if not self._labels_store:
-            for k in sorted(self._unscored_merged):
-                if self._unscored_merged[k]:
-                    result = self._unscored_merged[k][0]
-                    self.__dict__["_cache_labels_best_merged"] = result
-                    return result
-            raise ValueError("No labels have been added")
-
         result = self._labels_best._merged_full
         self.__dict__["_cache_labels_best_merged"] = result
+
         return result

--- a/opendsm/common/clustering/metrics/single_k_metrics.py
+++ b/opendsm/common/clustering/metrics/single_k_metrics.py
@@ -339,6 +339,16 @@ class SingleKMetrics(ArbitraryPydanticModel):
         return len(self.unique_labels)
 
     @computed_field_cached_property()
+    def unique_valid_labels(self) -> np.ndarray:
+        labels = self.unique_labels
+
+        return labels[labels >= 0]
+
+    @computed_field_cached_property()
+    def valid_label_count(self) -> int:
+        return len(self.unique_valid_labels)
+
+    @computed_field_cached_property()
     def _is_single_cluster(self) -> bool:
         """True when there is only one cluster (k=1). Most indices are
         undefined for k=1 and should return NaN to abstain from voting."""

--- a/tests/common/clustering/test_algorithms.py
+++ b/tests/common/clustering/test_algorithms.py
@@ -23,7 +23,9 @@ import numpy as np
 import pytest
 
 from opendsm.common.clustering.algorithms.spectral import spectral
+from opendsm.common.clustering.algorithms.spectral.spectral_divisive import spectral_divisive
 from opendsm.common.clustering.algorithms.bisect_k_means import bisect_k_means
+from opendsm.common.clustering.algorithms.bisect_k_medians import bisect_k_medians
 
 from .conftest import make_clustering_settings
 
@@ -106,11 +108,19 @@ class TestAlgorithmSharedBehavior:
         assert len(labels) == 100
         assert len(np.unique(labels)) > 0
 
+    @pytest.mark.filterwarnings("ignore::sklearn.exceptions.ConvergenceWarning")
     @pytest.mark.parametrize("algorithm", _ALGORITHMS)
     def test_identical_samples(self, algorithm):
-        """All-identical data does not crash."""
+        """All-identical data is handled without a hang or IndexError: the
+        algorithm either returns a degenerate labeling or raises a clear
+        ValueError when the fixed k cannot be formed.
+        """
         data = np.ones((50, 10))
-        labels = _run(data, algorithm, n_lower=3, n_upper=3).labels
+        try:
+            labels = _run(data, algorithm, n_lower=3, n_upper=3).labels
+        except ValueError:
+            return
+
         assert len(labels) == 50
         assert len(np.unique(labels)) > 0
 
@@ -169,6 +179,44 @@ class TestAlgorithmSharedBehavior:
             segment = labels[i * 30:(i + 1) * 30]
             most_common = np.bincount(segment).argmax()
             assert np.sum(segment == most_common) >= 20
+
+
+# Bisection-family algorithms cannot manufacture clusters from identical
+# points (each split collapses to one side), so they report degeneracy
+# honestly — unlike spectral, whose k-means label step fabricates clusters.
+_BISECTION_ALGOS = {
+    "bisecting_kmedians": bisect_k_medians,
+    "spectral_divisive": spectral_divisive,
+}
+
+
+class TestDegenerateDataFallback:
+    """Unclusterable data: terminate (no hang) and honour the k=1 allowance."""
+
+    @pytest.mark.parametrize("algorithm", list(_BISECTION_ALGOS))
+    def test_k1_allowed_returns_single_cluster(self, algorithm):
+        """Identical data with k=1 allowed terminates and yields one cluster."""
+        data = np.ones((30, 4))
+        algo_kw = {algorithm: {"n_cluster": {"lower": 1, "upper": 6}}}
+        cs = make_clustering_settings(algorithm, **algo_kw)
+
+        result = _BISECTION_ALGOS[algorithm](data, cs)
+
+        assert result.k == 1
+
+    @pytest.mark.parametrize("algorithm", list(_BISECTION_ALGOS))
+    def test_k1_disallowed_raises(self, algorithm):
+        """Identical data with k=1 disallowed terminates and raises rather
+        than returning a below-lower-bound clustering.
+        """
+        data = np.ones((30, 4))
+        algo_kw = {algorithm: {"n_cluster": {"lower": 2, "upper": 6}}}
+        cs = make_clustering_settings(algorithm, **algo_kw)
+
+        result = _BISECTION_ALGOS[algorithm](data, cs)
+
+        with pytest.raises(ValueError):
+            _ = result.k
 
 
 if __name__ == "__main__":

--- a/tests/common/clustering/test_null_tests.py
+++ b/tests/common/clustering/test_null_tests.py
@@ -12,8 +12,9 @@ from opendsm.common.clustering.metrics.cross_k_metrics import (
     CrossKMetrics,
     has_cluster_structure,
 )
+from opendsm.common.clustering.metrics import selection as _selection
 from opendsm.common.clustering.metrics.labels import ClusteringResult
-from opendsm.common.clustering.metrics.settings import ScoreSettings
+from opendsm.common.clustering.metrics.settings import ScoreSettings, SmallClusterMode
 from opendsm.common.clustering.metrics.single_k_metrics import SingleKMetrics
 
 
@@ -436,6 +437,109 @@ class TestLabelsIntegrationEdgeCases:
         # The result must be k>=2 (the good labeling), not k=1
         assert cr.k >= 2
         assert cr.has_cluster_structure is True
+
+    @pytest.mark.parametrize("lower, k1_allowed", [(1, True), (2, False)])
+    def test_degenerate_labeling_respects_k1_allowance(self, lower, k1_allowed):
+        """A labeling that collapses to one cluster is returned as a single
+        cluster when the lower bound allows k=1, and raises a clear error
+        (naming n_cluster_lower) when it does not.
+        """
+        rng = np.random.default_rng(0)
+        X = rng.normal(0, 1, (40, 4))
+
+        # OUTLIER trimming sends the lone 2-point cluster to -1, collapsing
+        # the labeling to a single cluster.
+        cr = ClusteringResult(
+            data=X, seed=42, n_cluster_lower=lower, min_cluster_size=3,
+            small_cluster_mode=SmallClusterMode.OUTLIER,
+        )
+        labels = np.zeros(40, dtype=int)
+        labels[:2] = 1
+        cr.add(2, labels)
+
+        if k1_allowed:
+            assert cr.k == 1
+            assert cr.selection_confidence == 1.0
+        else:
+            assert not cr._labels_store
+            for accessor in ("k", "metrics", "labels"):
+                with pytest.raises(ValueError, match=f"n_cluster_lower={lower}"):
+                    getattr(cr, accessor)
+
+    def test_valid_label_count_excludes_outliers(self):
+        """valid_label_count / unique_valid_labels drop the -1 outlier label,
+        while label_count / unique_labels keep it as a literal unique label.
+        """
+        X = np.random.default_rng(0).normal(0, 1, (10, 3)).astype(np.float32)
+        labels = np.array([0, 0, 0, 1, 1, 1, -1, -1, 2, 2])
+        lm = SingleKMetrics(data=X, labels=labels, distance_metric="euclidean", seed=0)
+
+        assert lm.label_count == 4
+        assert -1 in lm.unique_labels
+        assert lm.valid_label_count == 3
+        assert -1 not in lm.unique_valid_labels
+
+    def test_single_specified_k_bypasses_cross_k_selection(self, monkeypatch):
+        """With a single specified k, the within-k best is returned with
+        full confidence and the cross-k council never runs.
+        """
+        rng = np.random.default_rng(1)
+        X = np.vstack([rng.normal(c, 0.3, (20, 4)) for c in (0, 5, 10)])
+
+        cr = ClusteringResult(data=X, seed=42, n_cluster_lower=3)
+        cr.add(3, KMeans(n_clusters=3, n_init=3, random_state=0).fit_predict(X))
+        cr.add(3, KMeans(n_clusters=3, n_init=3, random_state=1).fit_predict(X))
+
+        def _must_not_run(*args, **kwargs):
+            raise AssertionError("cross-k council should be bypassed for one k")
+
+        monkeypatch.setattr(_selection, "select_best_across_k", _must_not_run)
+
+        assert cr.k_values == [3]
+        assert cr.k == 3
+        assert cr.selection_confidence == 1.0
+
+    def test_metrics_raise_when_no_labels_added(self):
+        """Accessing metrics on a result with no labels at all raises a
+        distinct message from the all-rejected case.
+        """
+        rng = np.random.default_rng(2)
+        X = rng.normal(0, 1, (30, 4))
+
+        cr = ClusteringResult(data=X, seed=42)
+
+        with pytest.raises(ValueError, match="No labels have been added"):
+            _ = cr.metrics
+
+    def test_unscored_council_returns_smallest_specified_k(self, monkeypatch):
+        """When valid candidates exist but the council yields no scored
+        winner (None-slot), the result falls back to the candidate at the
+        smallest user-specified k (n_cluster_lower), not insertion order.
+        """
+        rng = np.random.default_rng(7)
+        X = np.vstack([rng.normal(c, 0.4, (25, 4)) for c in (0, 6, 12)])
+
+        cr = ClusteringResult(
+            data=X, seed=42, n_cluster_lower=2, min_cluster_size=3,
+            small_cluster_mode=SmallClusterMode.OUTLIER,
+        )
+        cr.add(2, KMeans(n_clusters=2, n_init=3, random_state=0).fit_predict(X))
+        cr.add(3, KMeans(n_clusters=3, n_init=3, random_state=0).fit_predict(X))
+        cr.add(4, KMeans(n_clusters=4, n_init=3, random_state=0).fit_predict(X))
+        # A rejected (collapsing) candidate: its 2-point cluster is outliered,
+        # dropping below the lower bound, so it becomes a None slot the
+        # council winner can land on, forcing the unscored fallback.
+        collapse = np.zeros(75, dtype=int)
+        collapse[:2] = 1
+        cr.add(2, collapse)
+
+        none_slot = cr._insertion_order.index(None)
+        monkeypatch.setattr(
+            _selection, "select_best_across_k",
+            lambda *a, **k: (none_slot, 0.0),
+        )
+
+        assert cr.k == 2
 
     def test_build_cross_k_extra_scores_injects_into_candidates(self):
         """_build_cross_k_extra_scores should return a list parallel to

--- a/tests/common/clustering/test_spectral.py
+++ b/tests/common/clustering/test_spectral.py
@@ -12,6 +12,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import sys
+
 import numpy as np
 import pytest
 from sklearn.datasets import make_blobs
@@ -1597,6 +1599,35 @@ class TestSubSeed:
         idx_a = np.array([10, 20, 30, 40])
         idx_b = np.array([11, 20, 30, 40])
         assert _sub_seed(42, idx_a) != _sub_seed(42, idx_b)
+
+
+class TestSparseEigshFallback:
+    """The sparse self-tuning path recovers via a dense eigendecomposition
+    when ARPACK fails to converge."""
+
+    def test_dense_fallback_on_eigsh_failure(self, monkeypatch):
+        spectral_mod = sys.modules[spectral.__module__]
+
+        rng = np.random.default_rng(0)
+        X = np.vstack([rng.normal(c, 0.4, (20, 4)) for c in (0, 6, 12)])
+
+        # Force the sparse branch on small data, then make ARPACK fail so the
+        # dense fallback path runs.
+        monkeypatch.setattr(spectral_mod, "_SELF_TUNING_SPARSE_THRESHOLD", 5)
+
+        def _arpack_fails(*args, **kwargs):
+            raise RuntimeError("ARPACK did not converge")
+
+        monkeypatch.setattr(spectral_mod, "_sparse_eigsh", _arpack_fails)
+
+        cs = _spectral_cs(SpectralSettings(
+            affinity="self_tuning",
+            n_cluster={"lower": 2, "upper": 4},
+        ))
+        result = spectral(X, cs)
+
+        assert len(result.labels) == len(X)
+        assert result.k >= 2
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure tests pass and coverage has not fallen.
- [x] Update the [CHANGELOG.md](../CHANGELOG.md) to describe your changes in a bulleted list under the "Development" section at the top of the changelog.
- [x] Make sure code style follows PEP 008.
- [x] Make sure new public functions, classes, and methods have google-style docstrings.
- [x] Make sure that all git commits have the "Signed-off-by" message for the Developer Certificate of Origin.

### Description

Hardens the clustering selection layer and algorithms against degenerate / unclusterable data. Originally a single `IndexError`; review surfaced two more failure modes in the same area, fixed together here.

**Selection layer (`metrics/labels.py`)**
- **`IndexError` on empty result.** When every candidate labeling was rejected by `prepare_labels` (empty `_labels_store` — e.g. all collapsed below `n_cluster_lower` after small-cluster handling), `_compute_labels_best` fell through to `return all_valid[0]` and raised `IndexError`. It now raises a clear `ValueError` naming `n_cluster_lower`. When `k=1` **is** allowed (`n_cluster_lower <= 1`), degenerate data instead returns the single cluster — no error.
- **Unscored council fallback.** When valid candidates exist but the council returns no scored winner, the fallback now returns the labeling with the **fewest clusters** (which is `>= n_cluster_lower` by construction), never the insertion-order-first candidate and never a count below the lower bound.
- **Single specified k.** With one distinct `k`, the gap gate and cross-k council are bypassed; the within-k best is returned with full confidence.

**Metrics (`metrics/single_k_metrics.py`)**
- Add `unique_valid_labels` / `valid_label_count`, which exclude the `-1` outlier label (`unique_labels` / `label_count` stay literal). `ClusteringResult.k` now uses the valid count.

**Algorithms**
- **`bisect_k_medians` infinite loop.** A node that couldn't be bisected into two `min_cluster_size` halves was re-pushed unchanged, so on unsplittable data (e.g. identical points) the heap never drained and the run **hung**. Split retries are now bounded; after the budget the node is accepted as a terminal cluster.
- **`spectral` ARPACK non-convergence.** The sparse self-tuning path wrapped `eigsh` in a no-op `except: raise`. It now falls back to a dense `eigh` of the smallest eigenpairs when ARPACK fails to converge.

#### Tests

Degenerate-data matrix at both the `ClusteringResult` and algorithm levels (k=1 allowed → single cluster; k=1 disallowed → `ValueError`), the unscored-council smallest-k fallback, the single-k bypass, `valid_label_count` outlier exclusion, and the dense `eigsh` fallback. Full clustering suite: 611 passed.

#### Note

Spectral's k-means label-assignment step fabricates the requested number of (meaningless) clusters from a degenerate embedding rather than reporting degeneracy — unlike the bisection family, which collapses honestly. Left out of scope here; can be a follow-up if degeneracy detection for spectral is wanted.