### PR TITLE
Autocorrelation: FFT path for many lags, drop unused variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 Development
 -----------
 
+* `common/hourly_interpolation`: `_autocorr_fcn` computes the autocorrelation via FFT above 16 lags and the masked loop at or below, returning identical values (missing data is zero-filled after centering, so it contributes 0 to each lag product). Remove the unused `_autocorr_fcn2` / `_autocorr_fcn3` reference variants; raise on an unknown backup interpolation method. Add direct characterization tests pinning both branches to the original output.
 * Bug fix (`clustering`): degenerate-data handling across the selection and algorithm layers.
   - `ClusteringResult`: `.k` / `.metrics` / `.labels` raised `IndexError` when every candidate labeling was rejected by `prepare_labels` (empty `_labels_store`, e.g. all collapsed below `n_cluster_lower`). They now raise a clear `ValueError` naming `n_cluster_lower` when `k=1` is disallowed, and return the single cluster when it is allowed.
   - `ClusteringResult`: when valid candidates exist but the council produces no scored winner, the fallback returns the labeling with the fewest clusters (`>= n_cluster_lower`) instead of the insertion-order-first one, and never a count below the lower bound.

--- a/opendsm/common/hourly_interpolation.py
+++ b/opendsm/common/hourly_interpolation.py
@@ -27,12 +27,20 @@ from sklearn.linear_model import BayesianRidge
 from scipy.interpolate import RBFInterpolator
 
 
+
+# At or below this many lags the direct masked loop is used; above it the FFT
+# path is used. Both paths return identical correlation values.
+_AUTOCORR_FFT_LAG_THRESHOLD = 16
+
+
 def _autocorr_fcn(x, lags, exclude_0=True):
     """Compute autocorrelation function for given lags.
 
-    Manually computes non-partial autocorrelation, handling missing values
-    via masked arrays. Returns both positive lags (future) and negative lags
-    (past) by mirroring the correlation values.
+    Computes non-partial autocorrelation, handling missing values via masked
+    arrays, and returns both positive lags (future) and negative lags (past) by
+    mirroring the correlation values. Few lags use a direct masked loop; many
+    lags use an FFT with missing values zero-filled after centering, which
+    contributes 0 to each lag product and so matches the masked-loop result.
 
     Args:
         x: Input array (may contain NaN values)
@@ -42,25 +50,34 @@ def _autocorr_fcn(x, lags, exclude_0=True):
     Returns:
         2D array with shape (n_lags, 2) containing [lag, correlation] pairs
     """
+    lags = np.asarray(lags)
     x_masked = ma.masked_invalid(x)
     mean = ma.mean(x_masked)
     var = ma.var(x_masked)
 
-    if var == 0:
+    if not np.isfinite(var) or var == 0:
         var = 1.0
 
-    x_centered = x_masked - mean
     n = len(x)
 
-    # Compute correlation for each lag
-    corr = np.zeros(len(lags))
+    if len(lags) <= _AUTOCORR_FFT_LAG_THRESHOLD:
+        x_centered = x_masked - mean
+        corr = np.zeros(len(lags))
 
-    for idx, lag in enumerate(lags):
-        if lag == 0:
-            corr[idx] = 1.0
-        else:
-            lag_corr = ma.sum(x_centered[lag:] * x_centered[:-lag]) / n / var
-            corr[idx] = ma.filled(lag_corr, 0.0)
+        for idx, lag in enumerate(lags):
+            if lag == 0:
+                corr[idx] = 1.0
+            else:
+                lag_corr = ma.sum(x_centered[lag:] * x_centered[:-lag]) / n / var
+                corr[idx] = ma.filled(lag_corr, 0.0)
+
+    else:
+        x_filled = ma.filled(x_masked - mean, 0.0)
+        spectrum = np.fft.rfft(x_filled, 2 * n)
+        acov = np.fft.irfft(spectrum * np.conj(spectrum), 2 * n)[:n] / n / var
+        safe_lags = np.clip(lags, 0, n - 1)
+        corr = np.where(lags < n, acov[safe_lags], 0.0)
+        corr[lags == 0] = 1.0
 
     result = np.vstack((lags, corr)).T
 
@@ -76,48 +93,6 @@ def _autocorr_fcn(x, lags, exclude_0=True):
     result = np.vstack((reversed_result, result))
 
     return result
-
-
-def _autocorr_fcn2(x, lags):
-    """Alternative autocorr using np.correlate (unused, kept for reference).
-
-    Computes non-partial autocorrelation using numpy's correlate function.
-    Generally slower than _autocorr_fcn for typical use cases.
-    """
-    x_masked = ma.masked_invalid(x)
-    mean = ma.mean(x_masked)
-    var = ma.var(x_masked)
-    x_centered = x_masked - mean
-
-    corr = ma.correlate(x_centered, x_centered, "full")[len(x) - 1:] / var / len(x)
-
-    return corr[:len(lags)]
-
-
-def _autocorr_fcn3(x, lags):
-    """Alternative autocorr using FFT (unused, kept for reference).
-
-    Computes non-partial autocorrelation using Fast Fourier Transform.
-    Most efficient for very long time series but has higher memory overhead.
-    """
-    x_masked = ma.masked_invalid(x)
-    n = len(x)
-
-    # Pad to nearest power of 2 for FFT efficiency
-    ext_size = 2 * n - 1
-    fft_size = 2 ** np.ceil(np.log2(ext_size)).astype("int")
-
-    mean = ma.mean(x_masked)
-    var = ma.var(x_masked)
-    x_centered = x - mean
-
-    # Compute autocorrelation via FFT
-    cf = np.fft.fft(x_centered, fft_size)
-    sf = cf.conjugate() * cf
-    corr = np.fft.ifft(sf).real
-    corr = corr / var / n
-
-    return corr[:len(lags)]
 
 
 def _multiple_imputation(df, columns=None, **kwargs):
@@ -345,6 +320,8 @@ def interpolate(df: pd.DataFrame, columns: Optional[List[str]] = None) -> pd.Dat
                 df[col] = df[col].ffill()
             elif method == "bfill":
                 df[col] = df[col].bfill()
+            else:
+                raise ValueError(f"Unknown interpolation method: {method!r}")
 
         # Create interpolation flag: True where originally missing and now filled
         df[flag_col] = False

--- a/tests/common/test_hourly_interpolation.py
+++ b/tests/common/test_hourly_interpolation.py
@@ -18,8 +18,13 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from opendsm.common.hourly_interpolation import interpolate
+from opendsm.common.hourly_interpolation import (
+    interpolate,
+    _autocorr_fcn,
+    _AUTOCORR_FFT_LAG_THRESHOLD,
+)
 from opendsm.common.test_data import load_test_data
+
 
 
 # =============================================================================
@@ -67,6 +72,7 @@ def periodic_series():
     """Create periodic time series data for autocorrelation testing."""
     np.random.seed(42)
     t = np.arange(0, 100)
+
     return np.sin(2 * np.pi * t / 24) + 0.1 * np.random.randn(100)
 
 
@@ -442,6 +448,161 @@ class TestInterpolateVsLinear:
         # Autocorr should handle solar patterns better
         assert mae_autocorr < mae_linear, \
             f"Autocorr MAE ({mae_autocorr:.2f} W/m²) should be < Linear MAE ({mae_linear:.2f} W/m²)"
+
+
+# =============================================================================
+# _autocorr_fcn — characterization & correctness (masked loop vs FFT branch)
+# =============================================================================
+
+def _deterministic_acf_signal(n=2000):
+    """Reproducible gappy signal: daily + weekly cycles + slow ramp, fixed gaps."""
+    t = np.arange(n, dtype=float)
+    x = np.sin(2 * np.pi * t / 24) + 0.5 * np.sin(2 * np.pi * t / 168) + 0.1 * t / n
+    x[::37] = np.nan
+    x[100:115] = np.nan
+
+    return x
+
+
+def _naive_acf(x, lags):
+    """Reference ACF: masked mean/var, sum of valid lag products / n / var."""
+    xm = np.ma.masked_invalid(x)
+    mean = xm.mean()
+    var = xm.var()
+
+    if not np.isfinite(var) or var == 0:
+        var = 1.0
+
+    xc = xm - mean
+    n = len(x)
+    out = np.zeros(len(lags))
+
+    for i, lag in enumerate(lags):
+        if lag == 0:
+            out[i] = 1.0
+        elif lag < n:
+            out[i] = float(np.ma.filled(np.ma.sum(xc[lag:] * xc[:-lag]) / n / var, 0.0))
+
+    return out
+
+
+def _pos_corr(result):
+    """{lag: corr} for lags >= 0 from the mirrored _autocorr_fcn output."""
+    return {int(lag): float(corr) for lag, corr in result if lag >= 0}
+
+
+class TestAutocorrFcn:
+    """The masked-loop and FFT branches must agree and stay pinned to the original."""
+
+    # Pinned from the original masked-loop implementation on _deterministic_acf_signal().
+    REFERENCE = {
+        0: 1.0,
+        1: 0.9122603913,
+        2: 0.8362625721,
+        3: 0.7155700045,
+        4: 0.5588584332,
+        5: 0.37680267,
+        6: 0.1817630883,
+        7: -0.0130593771,
+        8: -0.1945236306,
+    }
+
+    def test_loop_branch_matches_pinned_reference(self):
+        """Few lags (<= threshold) take the masked loop and reproduce the pinned values."""
+        assert len(self.REFERENCE) <= _AUTOCORR_FFT_LAG_THRESHOLD
+        x = _deterministic_acf_signal()
+        corr = _pos_corr(_autocorr_fcn(x, np.arange(0, len(self.REFERENCE)), exclude_0=False))
+
+        for lag, expected in self.REFERENCE.items():
+            assert corr[lag] == pytest.approx(expected, abs=1e-8), f"lag {lag}"
+
+    def test_fft_branch_matches_pinned_reference(self):
+        """Many lags (> threshold) take the FFT path and reproduce the same pinned values."""
+        x = _deterministic_acf_signal()
+        corr = _pos_corr(
+            _autocorr_fcn(x, np.arange(0, _AUTOCORR_FFT_LAG_THRESHOLD + 50), exclude_0=False)
+        )
+
+        for lag, expected in self.REFERENCE.items():
+            assert corr[lag] == pytest.approx(expected, abs=1e-8), f"lag {lag}"
+
+    def test_loop_and_fft_branches_agree(self):
+        """The two branches return identical correlations on their shared lags."""
+        x = _deterministic_acf_signal()
+        few = _pos_corr(
+            _autocorr_fcn(x, np.arange(0, _AUTOCORR_FFT_LAG_THRESHOLD), exclude_0=False)
+        )
+        many = _pos_corr(
+            _autocorr_fcn(x, np.arange(0, _AUTOCORR_FFT_LAG_THRESHOLD + 100), exclude_0=False)
+        )
+
+        for lag in few:
+            assert few[lag] == pytest.approx(many[lag], abs=1e-10), f"lag {lag}"
+
+    @pytest.mark.parametrize("n_lags", [6, _AUTOCORR_FFT_LAG_THRESHOLD + 30])
+    def test_matches_naive_reference(self, n_lags):
+        """Both branches match an independent naive masked-loop reference."""
+        x = _deterministic_acf_signal()
+        lags = np.arange(0, n_lags)
+        got = _pos_corr(_autocorr_fcn(x, lags, exclude_0=False))
+        expected = _naive_acf(x, lags)
+
+        for lag in lags:
+            assert got[int(lag)] == pytest.approx(expected[lag], abs=1e-10), f"lag {lag}"
+
+    def test_recovers_ar1_theoretical_acf(self):
+        """AR(1) with phi=0.7 has ACF(k)=0.7**k; the FFT branch recovers it from data."""
+        rng = np.random.default_rng(0)
+        phi = 0.7
+        e = rng.standard_normal(20_000)
+        x = np.empty_like(e)
+        x[0] = e[0]
+
+        for i in range(1, len(e)):
+            x[i] = phi * x[i - 1] + e[i]
+
+        corr = _pos_corr(_autocorr_fcn(x, np.arange(0, 30), exclude_0=False))
+
+        for k in range(1, 6):
+            assert corr[k] == pytest.approx(phi ** k, abs=0.03), f"lag {k}"
+
+    def test_constant_input_is_zero_beyond_lag0(self):
+        """Constant input (var=0) is guarded: lag 0 = 1, all other lags = 0."""
+        x = np.full(500, 7.0)
+        corr = _pos_corr(_autocorr_fcn(x, np.arange(0, 6), exclude_0=False))
+
+        assert corr[0] == 1.0
+        assert all(corr[lag] == 0.0 for lag in range(1, 6))
+
+    def test_all_nan_input_is_finite(self):
+        """All-NaN input does not crash and yields finite correlations."""
+        x = np.full(200, np.nan)
+        result = _autocorr_fcn(x, np.arange(0, 6))
+
+        assert np.isfinite(result[:, 1]).all()
+
+    def test_lags_at_least_n_are_zero(self):
+        """Lags >= series length return 0 with no out-of-range access."""
+        x = np.array([1.0, 2.0, 3.0, 4.0])
+        corr = _pos_corr(_autocorr_fcn(x, np.arange(0, 6), exclude_0=False))
+
+        assert corr[4] == 0.0
+        assert corr[5] == 0.0
+
+    def test_exclude_0_drops_zero_lag_and_mirrors(self):
+        """exclude_0=True removes lag 0; correlations are symmetric in lag sign."""
+        x = _deterministic_acf_signal()
+        lags = np.arange(0, 5)
+        with_0 = _autocorr_fcn(x, lags, exclude_0=False)
+        without_0 = _autocorr_fcn(x, lags, exclude_0=True)
+
+        assert 0 in with_0[:, 0]
+        assert 0 not in without_0[:, 0]
+
+        signed = {int(lag): float(corr) for lag, corr in with_0}
+
+        for lag in range(1, 5):
+            assert signed[lag] == pytest.approx(signed[-lag], abs=1e-12), f"lag {lag}"
 
 
 # =============================================================================


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Requesting to pull a feature branch (`feature/autocorr-fft-zerofill`) into `master`.
- [x] Tests pass and coverage not reduced — `tests/common/test_hourly_interpolation.py`: 28 passed (run serially). The new `TestAutocorrFcn` covers both the loop and FFT branches plus edge cases.
- [x] `CHANGELOG.md` updated with a bullet under the **Development** section.
- [ ] `blacken` intentionally not run — the touched files keep the repo's existing in-file style (which diverges from black, e.g. three blank lines after imports), so no formatting-only churn is included.
- [x] `_autocorr_fcn` keeps its google-style docstring (updated to describe the lag dispatch). Internal function; no public API change.
- [x] Commit is signed off for the DCO.

### Description

`_autocorr_fcn` computed the autocorrelation with an `O(n·k)` masked Python loop over `k` lags. The hourly interpolation path requests up to `2*HOURS_PER_WEEK + 1 = 337` lags, where that loop dominates.

This adds an FFT path and dispatches on lag count:

- **≤ 16 lags:** the existing masked loop (unchanged).
- **> 16 lags:** FFT autocorrelation. Missing values are zero-filled after centering on the masked mean, so they contribute `0` to each lag product — identical to the masked sum — and normalization is the same `/ n / var`.

Both paths return identical values. A new characterization test (`TestAutocorrFcn`) pins both branches to the original output on a deterministic gappy signal (loop `Δ = 0`, FFT `Δ ≤ 3e-16`), checks the branches agree with each other and with an independent naive reference, recovers the AR(1) theoretical ACF (`0.7**k`) from data, and covers constant / all-NaN / `lags ≥ n` / `exclude_0`.

Timing on one year of hourly data with NaN gaps (the live condition):

| lags | before (loop) | after |
|---|---|---|
| 25 | 1.28 ms | 0.71 ms |
| 169 | 5.87 ms | 0.54 ms |
| 337 | 12.64 ms | 0.51 ms |

Also in this PR:

- Removed the unused `_autocorr_fcn2` (`np.correlate`) and `_autocorr_fcn3` (FFT) reference variants. Both returned `NaN` on any missing value and had no callers; the new FFT path supersedes the FFT variant while handling gaps.
- `_multiple_imputation`: the backup-interpolation dispatch now raises on an unrecognized method (final `else`) instead of silently skipping.
